### PR TITLE
Updated travis.yml with github pages #11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,13 @@ install: ./gradlew assemble -x javadoc -x signArchives
 script: ./gradlew test
 after_success:
 - ./gradlew jacocoTestReport coveralls
+before_deploy:
+  - ./gradlew javadoc
+deploy:
+  provider: pages
+  skip_cleanup: true
+  keep-history: true
+  local_dir: build/docs/javadoc
+  github_token: $GITHUB_TOKEN
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 install: ./gradlew assemble -x javadoc -x signArchives
 script: ./gradlew test
 after_success:
-- ./gradlew jacocoTestReport coveralls
+  - ./gradlew jacocoTestReport coveralls
 before_deploy:
   - ./gradlew javadoc
 deploy:

--- a/build.gradle
+++ b/build.gradle
@@ -265,3 +265,11 @@ junitPlatformTest {
         destinationFile = file("${buildDir}/jacoco/test.exec")
     }
 }
+// Disable docs lint if Java8
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}


### PR DESCRIPTION
Set environment variable GITHUB_TOKEN on travis-ci.

Do not merge yet: Doclint has been disabled for Java8: 
https://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html