### PR TITLE
#24 Update Transaction Type values to sync with cow release. 

### DIFF
--- a/src/main/java/io/nem/sdk/model/transaction/TransactionType.java
+++ b/src/main/java/io/nem/sdk/model/transaction/TransactionType.java
@@ -36,12 +36,12 @@ public enum TransactionType {
     /**
      * Mosaic definition transaction type.
      */
-    MOSAIC_DEFINITION(0x414d),
+    MOSAIC_DEFINITION(0x414D),
 
     /**
      * Mosaic supply change transaction.
      */
-    MOSAIC_SUPPLY_CHANGE(0x424d),
+    MOSAIC_SUPPLY_CHANGE(0x424D),
 
     /**
      * Modify multisig account transaction type.
@@ -51,7 +51,7 @@ public enum TransactionType {
     /**
      * Register namespace transaction type.
      */
-    REGISTER_NAMESPACE(0x414e),
+    REGISTER_NAMESPACE(0x414E),
 
     /**
      * Transfer Transaction transaction type.
@@ -61,17 +61,17 @@ public enum TransactionType {
     /**
      * Lock transaction type
      */
-    LOCK(0x414C),
+    LOCK(0x4148),
 
     /**
      * Secret Lock Transaction type
      */
-    SECRET_LOCK(0x424C),
+    SECRET_LOCK(0x4152),
 
     /**
      * Secret Proof transaction type
      */
-    SECRET_PROOF(0x434C);
+    SECRET_PROOF(0x4252);
 
     private int value;
 
@@ -105,11 +105,11 @@ public enum TransactionType {
                 return TransactionType.MOSAIC_SUPPLY_CHANGE;
             case 16725:
                 return TransactionType.MODIFY_MULTISIG_ACCOUNT;
-            case 16716:
+            case 16712:
                 return TransactionType.LOCK;
-            case 16972:
+            case 16722:
                 return TransactionType.SECRET_LOCK;
-            case 17228:
+            case 16978:
                 return TransactionType.SECRET_PROOF;
             case 16705:
                 return TransactionType.AGGREGATE_COMPLETE;

--- a/src/test/java/io/nem/sdk/model/transaction/TransactionTypeTest.java
+++ b/src/test/java/io/nem/sdk/model/transaction/TransactionTypeTest.java
@@ -80,24 +80,24 @@ class TransactionTypeTest {
     @Test
     void lockFundsType() {
         TransactionType transactionType = TransactionType.LOCK;
-        assertEquals(0x414C, transactionType.getValue());
-        assertEquals(16716, transactionType.getValue());
-        assertEquals(TransactionType.LOCK, TransactionType.rawValueOf(16716));
+        assertEquals(0x4148, transactionType.getValue());
+        assertEquals(16712, transactionType.getValue());
+        assertEquals(TransactionType.LOCK, TransactionType.rawValueOf(16712));
     }
 
     @Test
     void secretLockType() {
         TransactionType transactionType = TransactionType.SECRET_LOCK;
-        assertEquals(0x424C, transactionType.getValue());
-        assertEquals(16972, transactionType.getValue());
-        assertEquals(TransactionType.SECRET_LOCK, TransactionType.rawValueOf(16972));
+        assertEquals(0x4152, transactionType.getValue());
+        assertEquals(16722, transactionType.getValue());
+        assertEquals(TransactionType.SECRET_LOCK, TransactionType.rawValueOf(16722));
     }
 
     @Test
     void secretProofType() {
         TransactionType transactionType = TransactionType.SECRET_PROOF;
-        assertEquals(0x434C, transactionType.getValue());
-        assertEquals(17228, transactionType.getValue());
-        assertEquals(TransactionType.SECRET_PROOF, TransactionType.rawValueOf(17228));
+        assertEquals(0x4252, transactionType.getValue());
+        assertEquals(16978, transactionType.getValue());
+        assertEquals(TransactionType.SECRET_PROOF, TransactionType.rawValueOf(16978));
     }
 }


### PR DESCRIPTION
Updated TransactionType enums to sync with cow release. Also uppercased the hex values for consistency with catapult-rest.

Closes #24 