### PR TITLE
JS-22 Enabled Sonarqube in master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,15 @@ install:
 script:
   - ./gradlew install jacocoTestReport coveralls -x javadoc
 deploy:
-  provider: script
-  skip_cleanup: true
-  script: /bin/sh release.sh
-  on:
-    branch: master
-    jdk: oraclejdk8
+  - provider: script
+    skip_cleanup: true
+    script: /bin/sh uploadArchives.sh
+    on:
+      branch: master
+      jdk: oraclejdk8
+  - provider: script
+    skip_cleanup: true
+    script: /bin/sh sonarqube.sh
+    on:
+      branch: master
+      jdk: oraclejdk9

--- a/build.gradle
+++ b/build.gradle
@@ -272,8 +272,9 @@ def gitBranch() {
 
 sonarqube {
     properties {
-        property "sonar.branch.name", sonarBranchName == null ? gitBranch() : sonarBranchName
+        // property "sonar.branch.name", sonarBranchName == null ? gitBranch() : sonarBranchName
         property "sonar.projectKey", sonarProjectKey
+        property "sonar.projectName", sonarProjectKey
         property "sonar.organization", sonarOrganization
         property "sonar.login", sonarLogin
         property "sonar.host.url", sonarHostUrl

--- a/release.sh
+++ b/release.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-echo "Uploading generated clients jars"
-./gradlew -b ./openapi-generator/build.gradle uploadArchives
-
-echo "Uploading sdk jars"
-./gradlew uploadArchives

--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Running sonarqube"
+./gradlew sonarqube -x test

--- a/uploadArchives.sh
+++ b/uploadArchives.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Uploading generated clients jars"
+./gradlew -b ./openapi-generator/build.gradle uploadArchives -x javadoc
+
+echo "Uploading sdk jars"
+./gradlew uploadArchives -x javadoc


### PR DESCRIPTION
Hi Steve, 

This PR enables sonarqube to be executed every time the build **oraclejdk9** from the master branch is executed.  As described in the issue ticket JS-22, our community edition doesn't allow PR sonar analysis so we are only sending the report to sonar after a PR is merged.  

Note that **oraclejdk8** master build is the one in charge of uploading the jars to maven central snapshot. This way we can have some parallelism.  
