### PR TITLE
JS-10 Basic implementation of SignSchema.

### DIFF
--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountRepositoryIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountRepositoryIntegrationTest.java
@@ -139,7 +139,7 @@ class AccountRepositoryIntegrationTest extends BaseIntegrationTest {
         AccountRepository accountHttp = getRepositoryFactory(type).createAccountRepository();
         Address addressObject = Address
             .createFromPublicKey("67F69FA4BFCD158F6E1AF1ABC82F725F5C5C4710D6E29217B12BE66397435DFB",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
 
         try {
             accountHttp.getAccountInfo(addressObject).toFuture().get();

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/BaseIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/BaseIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.RepositoryFactory;
 import io.nem.sdk.infrastructure.okhttp.RepositoryFactoryOkHttpImpl;
 import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
@@ -34,6 +35,7 @@ import java.util.Map;
  */
 public abstract class BaseIntegrationTest {
 
+    protected static SignSchema signSchema = SignSchema.DEFAULT;
 
     /**
      * Known implementations of repositories that the integration tests use.
@@ -73,9 +75,9 @@ public abstract class BaseIntegrationTest {
 
         switch (type) {
             case VERTX:
-                return new RepositoryFactoryVertxImpl(getApiUrl());
+                return new RepositoryFactoryVertxImpl(getApiUrl(), signSchema);
             case OKHTTP:
-                return new RepositoryFactoryOkHttpImpl(getApiUrl());
+                return new RepositoryFactoryOkHttpImpl(getApiUrl(), signSchema);
             default:
                 throw new IllegalStateException("Invalid Repository type " + type);
         }
@@ -100,7 +102,7 @@ public abstract class BaseIntegrationTest {
         if (this.testAccount == null) {
             this.testAccount =
                 Account.createFromPrivateKey(
-                    this.config().getTestAccountPrivateKey(), this.getNetworkType());
+                    this.config().getTestAccountPrivateKey(), this.getNetworkType(), signSchema);
         }
         return this.testAccount;
     }
@@ -109,7 +111,7 @@ public abstract class BaseIntegrationTest {
         if (this.testPublicAccount == null) {
             this.testPublicAccount =
                 PublicAccount.createFromPublicKey(
-                    this.config().getTestAccountPublicKey(), this.getNetworkType());
+                    this.config().getTestAccountPublicKey(), this.getNetworkType(), SignSchema.DEFAULT);
         }
         return this.testPublicAccount;
     }
@@ -126,7 +128,7 @@ public abstract class BaseIntegrationTest {
         if (this.testMultisigAccount == null) {
             this.testMultisigAccount =
                 Account.createFromPrivateKey(
-                    this.config().getMultisigAccountPrivateKey(), this.getNetworkType());
+                    this.config().getMultisigAccountPrivateKey(), this.getNetworkType(), signSchema);
         }
         return this.testMultisigAccount;
     }
@@ -135,7 +137,8 @@ public abstract class BaseIntegrationTest {
         if (this.testCosignatoryAccount == null) {
             this.testCosignatoryAccount =
                 Account.createFromPrivateKey(
-                    this.config().getCosignatoryAccountPrivateKey(), this.getNetworkType());
+                    this.config().getCosignatoryAccountPrivateKey(), this.getNetworkType(),
+                    signSchema);
         }
         return this.testCosignatoryAccount;
     }
@@ -144,7 +147,8 @@ public abstract class BaseIntegrationTest {
         if (this.testCosignatoryAccount2 == null) {
             this.testCosignatoryAccount2 =
                 Account.createFromPrivateKey(
-                    this.config().getCosignatory2AccountPrivateKey(), this.getNetworkType());
+                    this.config().getCosignatory2AccountPrivateKey(), this.getNetworkType(),
+                    signSchema);
         }
         return this.testCosignatoryAccount2;
     }

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/ListenerIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/ListenerIntegrationTest.java
@@ -71,15 +71,15 @@ class ListenerIntegrationTest extends BaseIntegrationTest {
         multisigAccount =
             new Account(
                 "5edebfdbeb32e9146d05ffd232c8af2cf9f396caf9954289daa0362d097fff3b",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         cosignatoryAccount =
             new Account(
                 "2a2b1f5d366a5dd5dc56c3c757cf4fe6c66e2787087692cf329d7a49a594658b",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         cosignatoryAccount2 =
             new Account(
                 "b8afae6f4ad13a1b8aad047b488e0738a437c7389d4ff30c359ac068910c1d59",
-                NetworkType.MIJIN);
+                NetworkType.MIJIN, signSchema);
         generationHash = this.getGenerationHash();
     }
 

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/NamespaceRepositoryIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/NamespaceRepositoryIntegrationTest.java
@@ -18,6 +18,7 @@ package io.nem.sdk.infrastructure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.NamespaceRepository;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.account.PublicAccount;
@@ -47,7 +48,8 @@ class NamespaceRepositoryIntegrationTest extends BaseIntegrationTest {
     void setup() {
         // String publicKey = "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF";
         String publicKey = "F227B3268481DF7F9825CFB7C2051F441A9BC0C65FA0AA2CF3A438C4B3177B81";
-        publicAccount = PublicAccount.createFromPublicKey(publicKey, NetworkType.MIJIN_TEST);
+        publicAccount = PublicAccount.createFromPublicKey(publicKey, NetworkType.MIJIN_TEST,
+            SignSchema.DEFAULT);
         namespaceId = NetworkCurrencyMosaic.NAMESPACEID;
     }
 

--- a/sdk-core/src/main/java/io/nem/core/crypto/KeyPair.java
+++ b/sdk-core/src/main/java/io/nem/core/crypto/KeyPair.java
@@ -16,6 +16,9 @@
 
 package io.nem.core.crypto;
 
+/**
+ * It represents an asymmetric private/public encryption key.
+ */
 public class KeyPair {
 
     private final PrivateKey privateKey;

--- a/sdk-core/src/main/java/io/nem/core/crypto/RawAddress.java
+++ b/sdk-core/src/main/java/io/nem/core/crypto/RawAddress.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019. NEM
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.nem.core.crypto;
+
+import io.nem.core.crypto.Hashes;
+import io.nem.core.crypto.SignSchema;
+import io.nem.core.utils.ArrayUtils;
+import io.nem.core.utils.Base32Encoder;
+import io.nem.sdk.model.blockchain.NetworkType;
+import java.util.Arrays;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+
+/**
+ * Utility class that knows how to create an address based on a public key. It supports the
+ * different hashes algorithms defined in {@link SignSchema}.
+ */
+public class RawAddress {
+
+    private static final int NUM_CHECKSUM_BYTES = 4;
+
+    /**
+     * Private utility class constructor.
+     */
+    private RawAddress() {
+        //private utility class constructor.
+    }
+
+    /**
+     * This method generates an address based on the public key, and the Catapult configuration
+     * network type and sign schema.
+     *
+     * @param publicKey the public key
+     * @param networkType the network type
+     * @param signSchema the signature
+     * @return an encoded address that can be used to identify accounts.
+     */
+    public static String generateAddress(final String publicKey, final NetworkType networkType,
+        final SignSchema signSchema) {
+        byte version = (byte) networkType.getValue();
+        // step 1: sha3 hash of the public key
+        byte[] publicKeyBytes;
+        try {
+            publicKeyBytes = Hex.decodeHex(publicKey);
+        } catch (DecoderException e) {
+            throw new IllegalArgumentException("Public key is not valid");
+        }
+        final byte[] publicKeyHash = toHash(publicKeyBytes, signSchema);
+
+        // step 2: ripemd160 hash of (1)
+        final byte[] ripemd160StepOneHash = Hashes.ripemd160(publicKeyHash);
+
+        // step 3: add version byte in front of (2)
+        final byte[] versionPrefixedRipemd160Hash =
+            ArrayUtils.concat(new byte[]{version}, ripemd160StepOneHash);
+
+        // step 4: get the checksum of (3)
+        final byte[] stepThreeChecksum = generateChecksum(versionPrefixedRipemd160Hash, signSchema);
+
+        // step 5: concatenate (3) and (4)
+        final byte[] concatStepThreeAndStepSix =
+            ArrayUtils.concat(versionPrefixedRipemd160Hash, stepThreeChecksum);
+
+        // step 6: base32 encode (5)
+        return Base32Encoder.getString(concatStepThreeAndStepSix);
+    }
+
+    private static byte[] toHash(byte[] publicKeyBytes, SignSchema signSchema) {
+        if (signSchema == SignSchema.SHA3) {
+            return Hashes.sha3_256(publicKeyBytes);
+        }
+
+        if (signSchema == SignSchema.KECCAK_REVERSED_KEY) {
+            return Hashes.keccak256(publicKeyBytes);
+        }
+        throw new IllegalStateException("Unknown SignSchema " + signSchema);
+    }
+
+    private static byte[] generateChecksum(final byte[] input, SignSchema signSchema) {
+        // step 1: sha3 hash of (input
+        final byte[] sha3StepThreeHash = toHash(input, signSchema);
+
+        // step 2: get the first X bytes of (1)
+        return Arrays.copyOfRange(sha3StepThreeHash, 0, NUM_CHECKSUM_BYTES);
+    }
+}

--- a/sdk-core/src/main/java/io/nem/core/crypto/SignSchema.java
+++ b/sdk-core/src/main/java/io/nem/core/crypto/SignSchema.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019. NEM
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.nem.core.crypto;
+
+/**
+ * This enum defines the strategies that can be used when generating public addresses.
+ */
+public enum SignSchema {
+
+    /**
+     * SHA3 hash algorithm without key reversal
+     */
+    SHA3,
+    /**
+     * Keccak hash algorithm with reversed private keys.
+     */
+    KECCAK_REVERSED_KEY;
+
+    /**
+     * The default sign schema.
+     */
+    public static final SignSchema DEFAULT = SHA3;
+}

--- a/sdk-core/src/main/java/io/nem/sdk/model/account/Account.java
+++ b/sdk-core/src/main/java/io/nem/sdk/model/account/Account.java
@@ -18,6 +18,7 @@ package io.nem.sdk.model.account;
 
 import io.nem.core.crypto.KeyPair;
 import io.nem.core.crypto.PrivateKey;
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.transaction.AggregateTransaction;
 import io.nem.sdk.model.transaction.CosignatureSignedTransaction;
@@ -41,35 +42,45 @@ public class Account {
      * Constructor
      *
      * @param privateKey String
-     * @param networkType NetworkType
+     * @param networkType {@link NetworkType}
+     * @param signSchema the {@link SignSchema}
      */
-    public Account(String privateKey, NetworkType networkType) {
+    public Account(String privateKey, NetworkType networkType, SignSchema signSchema) {
         this.keyPair = new KeyPair(PrivateKey.fromHexString(privateKey));
-        this.publicAccount = new PublicAccount(this.getPublicKey(), networkType);
+        this.publicAccount = new PublicAccount(this.getPublicKey(), networkType, signSchema);
     }
 
-    public Account(KeyPair keyPair, NetworkType networkType) {
+    /**
+     * Constructor
+     *
+     * @param keyPair the public private key pair.
+     * @param networkType {@link NetworkType}
+     * @param signSchema the {@link SignSchema}
+     */
+    public Account(KeyPair keyPair, NetworkType networkType, SignSchema signSchema) {
         this.keyPair = keyPair;
-        this.publicAccount = new PublicAccount(this.getPublicKey(), networkType);
+        this.publicAccount = new PublicAccount(this.getPublicKey(), networkType, signSchema);
     }
 
     /**
      * Create an Account from a given private key.
      *
      * @param privateKey Private key from an account
-     * @param networkType NetworkType
+     * @param networkType {@link NetworkType}
+     * @param signSchema the {@link SignSchema}
      * @return {@link Account}
      */
-    public static Account createFromPrivateKey(String privateKey, NetworkType networkType) {
-        return new Account(privateKey, networkType);
+    public static Account createFromPrivateKey(String privateKey, NetworkType networkType,
+        SignSchema signSchema) {
+        return new Account(privateKey, networkType, signSchema);
     }
 
     /**
-     * Create an new Account
+     * It generates a new account for the given network.
      */
-    public static Account generateNewAccount(NetworkType networkType) {
+    public static Account generateNewAccount(NetworkType networkType, SignSchema signSchema) {
         KeyPair keyPair = new KeyPair();
-        return new Account(keyPair.getPrivateKey().toString(), networkType);
+        return new Account(keyPair.getPrivateKey().toString(), networkType, signSchema);
     }
 
     /**

--- a/sdk-core/src/main/java/io/nem/sdk/model/account/AccountInfo.java
+++ b/sdk-core/src/main/java/io/nem/sdk/model/account/AccountInfo.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.model.account;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.mosaic.Mosaic;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -133,7 +134,8 @@ public class AccountInfo {
      * @return {@link PublicAccount}
      */
     public PublicAccount getPublicAccount() {
-        return PublicAccount.createFromPublicKey(this.publicKey, this.address.getNetworkType());
+        return PublicAccount.createFromPublicKey(this.publicKey, this.address.getNetworkType(),
+            SignSchema.DEFAULT);
     }
 
     /**

--- a/sdk-core/src/main/java/io/nem/sdk/model/account/Address.java
+++ b/sdk-core/src/main/java/io/nem/sdk/model/account/Address.java
@@ -16,13 +16,11 @@
 
 package io.nem.sdk.model.account;
 
-import io.nem.core.crypto.Hashes;
-import io.nem.core.utils.ArrayUtils;
-import io.nem.core.utils.Base32Encoder;
+import io.nem.core.crypto.SignSchema;
+import io.nem.core.crypto.RawAddress;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Objects;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Base32;
@@ -36,7 +34,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
  */
 public class Address {
 
-    private static final int NUM_CHECKSUM_BYTES = 4;
+
     private final String plainAddress;
     private final NetworkType networkType;
 
@@ -102,50 +100,26 @@ public class Address {
     }
 
     /**
+     * Returns the encoded address.
+     *
+     * @return the encoded plain address.
+     */
+    public String encoded() {
+        return Hex.encodeHexString(new Base32().decode(plainAddress));
+    }
+
+    /**
      * Create from private key.
      *
      * @param publicKey String
-     * @param networkType NetworkType
+     * @param networkType the {@link NetworkType}
+     * @param signSchema the {@link SignSchema}
      * @return Address
      */
-    public static Address createFromPublicKey(String publicKey, NetworkType networkType) {
-        return new Address(generateEncoded((byte) networkType.getValue(), publicKey), networkType);
-    }
-
-    private static String generateEncoded(final byte version, final String publicKey) {
-        // step 1: sha3 hash of the public key
-        byte[] publicKeyBytes;
-        try {
-            publicKeyBytes = Hex.decodeHex(publicKey);
-        } catch (DecoderException e) {
-            throw new IllegalArgumentException("Public key is not valid");
-        }
-        final byte[] sha3PublicKeyHash = Hashes.sha3_256(publicKeyBytes);
-
-        // step 2: ripemd160 hash of (1)
-        final byte[] ripemd160StepOneHash = Hashes.ripemd160(sha3PublicKeyHash);
-
-        // step 3: add version byte in front of (2)
-        final byte[] versionPrefixedRipemd160Hash =
-            ArrayUtils.concat(new byte[]{version}, ripemd160StepOneHash);
-
-        // step 4: get the checksum of (3)
-        final byte[] stepThreeChecksum = generateChecksum(versionPrefixedRipemd160Hash);
-
-        // step 5: concatenate (3) and (4)
-        final byte[] concatStepThreeAndStepSix =
-            ArrayUtils.concat(versionPrefixedRipemd160Hash, stepThreeChecksum);
-
-        // step 6: base32 encode (5)
-        return Base32Encoder.getString(concatStepThreeAndStepSix);
-    }
-
-    private static byte[] generateChecksum(final byte[] input) {
-        // step 1: sha3 hash of (input
-        final byte[] sha3StepThreeHash = Hashes.sha3_256(input);
-
-        // step 2: get the first X bytes of (1)
-        return Arrays.copyOfRange(sha3StepThreeHash, 0, NUM_CHECKSUM_BYTES);
+    public static Address createFromPublicKey(String publicKey, NetworkType networkType,
+        SignSchema signSchema) {
+        return new Address(RawAddress.generateAddress(publicKey, networkType, signSchema),
+            networkType);
     }
 
     /**

--- a/sdk-core/src/main/java/io/nem/sdk/model/account/PublicAccount.java
+++ b/sdk-core/src/main/java/io/nem/sdk/model/account/PublicAccount.java
@@ -17,6 +17,7 @@
 package io.nem.sdk.model.account;
 
 import io.nem.core.crypto.PublicKey;
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.util.Objects;
 
@@ -30,8 +31,8 @@ public class PublicAccount {
     private final Address address;
     private final PublicKey publicKey;
 
-    public PublicAccount(String publicKey, NetworkType networkType) {
-        this.address = Address.createFromPublicKey(publicKey, networkType);
+    public PublicAccount(String publicKey, NetworkType networkType, SignSchema signSchema) {
+        this.address = Address.createFromPublicKey(publicKey, networkType, signSchema);
         this.publicKey = PublicKey.fromHexString(publicKey);
     }
 
@@ -40,10 +41,12 @@ public class PublicAccount {
      *
      * @param publicKey Public key
      * @param networkType NetworkType
+     * @param signSchema the {@link SignSchema}
      * @return {@link PublicAccount}
      */
-    public static PublicAccount createFromPublicKey(String publicKey, NetworkType networkType) {
-        return new PublicAccount(publicKey, networkType);
+    public static PublicAccount createFromPublicKey(String publicKey, NetworkType networkType,
+        SignSchema signSchema) {
+        return new PublicAccount(publicKey, networkType, signSchema);
     }
 
     /**
@@ -86,4 +89,6 @@ public class PublicAccount {
     public PublicKey getPublicKey() {
         return publicKey;
     }
+
+
 }

--- a/sdk-core/src/main/java/io/nem/sdk/model/blockchain/BlockInfo.java
+++ b/sdk-core/src/main/java/io/nem/sdk/model/blockchain/BlockInfo.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.model.blockchain;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import java.math.BigInteger;
 import java.util.List;
@@ -90,6 +91,7 @@ public class BlockInfo {
 
     @SuppressWarnings("squid:S00107")
     public static BlockInfo create(
+        SignSchema signSchema,
         String hash,
         String generationHash,
         BigInteger totalFee,
@@ -110,9 +112,10 @@ public class BlockInfo {
         String beneficiaryPublicKey) {
         NetworkType networkType = BlockInfo.getNetworkType(blockVersion);
         Integer transactionVersion = BlockInfo.getTransactionVersion(blockVersion);
-        PublicAccount signerPublicAccount = BlockInfo.getPublicAccount(signer, networkType);
+        PublicAccount signerPublicAccount = BlockInfo
+            .getPublicAccount(signer, networkType, signSchema);
         PublicAccount beneficiaryPublicAccount =
-            BlockInfo.getPublicAccount(beneficiaryPublicKey, networkType);
+            BlockInfo.getPublicAccount(beneficiaryPublicKey, networkType, signSchema);
         return new BlockInfo(
             hash,
             generationHash,
@@ -159,8 +162,9 @@ public class BlockInfo {
      *
      * @return public account
      */
-    public static PublicAccount getPublicAccount(String publicKey, NetworkType networkType) {
-        return new PublicAccount(publicKey, networkType);
+    public static PublicAccount getPublicAccount(String publicKey, NetworkType networkType,
+        SignSchema signSchema) {
+        return new PublicAccount(publicKey, networkType, signSchema);
     }
 
     /**
@@ -169,9 +173,10 @@ public class BlockInfo {
      * @return public account
      */
     public static Optional<PublicAccount> getPublicAccount(
-        Optional<String> publicKey, NetworkType networkType) {
+        Optional<String> publicKey, NetworkType networkType,
+        SignSchema signSchema) {
         if (publicKey.isPresent() && !publicKey.get().isEmpty()) {
-            return Optional.of(new PublicAccount(publicKey.get(), networkType));
+            return Optional.of(new PublicAccount(publicKey.get(), networkType, signSchema));
         } else {
             return Optional.empty();
         }

--- a/sdk-core/src/test/java/io/nem/sdk/model/account/AccountInfoTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/account/AccountInfoTest.java
@@ -18,6 +18,7 @@ package io.nem.sdk.model.account;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.mosaic.Mosaic;
 import io.nem.sdk.model.mosaic.NetworkCurrencyMosaic;
@@ -57,7 +58,7 @@ class AccountInfoTest {
         assertEquals(
             PublicAccount.createFromPublicKey(
                 "cf893ffcc47c33e7f68ab1db56365c156b0736824a0c1e273f9e00b8df8f01eb",
-                NetworkType.MIJIN_TEST),
+                NetworkType.MIJIN_TEST, SignSchema.DEFAULT),
             accountInfo.getPublicAccount());
 
         Assert.assertEquals(AccountType.REMOTE_UNLINKED,

--- a/sdk-core/src/test/java/io/nem/sdk/model/account/AccountTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/account/AccountTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import io.nem.core.crypto.KeyPair;
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.crypto.ed25519.Ed25519CryptoEngine;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.mosaic.Mosaic;
@@ -33,6 +34,8 @@ import java.util.Collections;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class AccountTest {
 
@@ -44,7 +47,7 @@ class AccountTest {
         Account account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, SignSchema.SHA3);
         assertEquals(
             "787225AAFF3D2C71F4FFA32D4F19EC4922F3CD869747F267378F81F8E3FCB12D",
             account.getPrivateKey());
@@ -59,7 +62,7 @@ class AccountTest {
         Account account =
             Account.createFromPrivateKey(
                 "787225AAFF3D2C71F4FFA32D4F19EC4922F3CD869747F267378F81F8E3FCB12D",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, SignSchema.SHA3);
         assertEquals(
             "787225AAFF3D2C71F4FFA32D4F19EC4922F3CD869747F267378F81F8E3FCB12D",
             account.getPrivateKey());
@@ -74,7 +77,7 @@ class AccountTest {
         Account account =
             Account.createFromPrivateKey(
                 "5098D500390934F81EA416D9A2F50F276DE446E28488E1801212931E3470DA31",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, SignSchema.SHA3);
         assertEquals(
             "5098D500390934F81EA416D9A2F50F276DE446E28488E1801212931E3470DA31",
             account.getPrivateKey());
@@ -90,7 +93,7 @@ class AccountTest {
         Account account =
             Account.createFromPrivateKey(
                 "B8AFAE6F4AD13A1B8AAD047B488E0738A437C7389D4FF30C359AC068910C1D59",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, SignSchema.SHA3);
         assertEquals(
             "B8AFAE6F4AD13A1B8AAD047B488E0738A437C7389D4FF30C359AC068910C1D59",
             account.getPrivateKey());
@@ -100,20 +103,22 @@ class AccountTest {
         assertEquals("SBE6CS7LZKJXLDVTNAC3VZ3AUVZDTF3PACNFIXFN", account.getAddress().plain());
     }
 
-    @Test
-    void generateNewAccountTest() {
-        Account account = Account.generateNewAccount(NetworkType.MIJIN_TEST);
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    void generateNewAccountTest(SignSchema signSchema) {
+        Account account = Account.generateNewAccount(NetworkType.MIJIN_TEST, signSchema);
         assertNotEquals(null, account.getPrivateKey());
         assertNotEquals(null, account.getPublicKey());
         assertEquals(64, account.getPrivateKey().length());
     }
 
-    @Test
-    void shouldSignTransaction() {
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    void shouldSignTransaction(SignSchema signSchema) {
         Account account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         TransferTransaction transferTransaction =
             TransferTransaction.create(
                 new FakeDeadline(),
@@ -135,10 +140,11 @@ class AccountTest {
             signedTransaction.getHash());
     }
 
-    @Test
-    void shouldAcceptKeyPairAsConstructor() {
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    void shouldAcceptKeyPairAsConstructor(SignSchema signSchema) {
         KeyPair random = KeyPair.random(new Ed25519CryptoEngine());
-        Account account = new Account(random, NetworkType.MIJIN_TEST);
+        Account account = new Account(random, NetworkType.MIJIN_TEST, signSchema);
         assertEquals(random.getPrivateKey().toString().toUpperCase(), account.getPrivateKey());
         assertEquals(NetworkType.MIJIN_TEST, account.getAddress().getNetworkType());
     }
@@ -147,7 +153,7 @@ class AccountTest {
     public void testAddresses2() {
         Address address = Address
             .createFromPublicKey("B630EFDDFADCC4A2077AB8F1EC846B08FEE2D2972EACF95BBAC6BFAC3D31834C",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, SignSchema.DEFAULT);
         Assert.assertEquals("SCUNEE-EE4FON-6N3DKD-FZUM6U-V7AU26-ZFTWT5-6NUX", address.pretty());
         Assert.assertEquals("SCUNEEEE4FON6N3DKDFZUM6UV7AU26ZFTWT56NUX", address.plain());
     }
@@ -156,7 +162,7 @@ class AccountTest {
     void shouldConstruct() {
         PublicAccount account1 = PublicAccount.createFromPublicKey(
             "A5F82EC8EBB341427B6785C8111906CD0DF18838FB11B51CE0E18B5E79DFF630",
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, SignSchema.DEFAULT);
 
         Assertions.assertEquals("SDWGJE7XOYRX5RQMMLWF4TE7U5Y2HUYBRDVX2OJE",
             account1.getAddress().plain());

--- a/sdk-core/src/test/java/io/nem/sdk/model/account/AddressTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/account/AddressTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class AddressTest {
@@ -47,7 +49,7 @@ class AddressTest {
             Arguments.of("NDGLFW-DSHILT-IUHGIB-H5UGX2-VYF5VN-JEKCCD-BR26", NetworkType.TEST_NET));
     }
 
-    private static Stream<Arguments> publicKeys() {
+    private static Stream<Arguments> publicKeysSha3() {
         return Stream.of(
             Arguments.of(
                 "b4f12e7c9f6946091e2cb8b6d3a12b50d17ccbbf646386ea27ce2946a7423dcf",
@@ -65,6 +67,38 @@ class AddressTest {
                 "b4f12e7c9f6946091e2cb8b6d3a12b50d17ccbbf646386ea27ce2946a7423dcf",
                 NetworkType.MAIN_NET,
                 "NARNASAS2BIAB6LMFA3FPMGBPGIJGK6IJFJKUV32"));
+    }
+
+    private static Stream<Arguments> publicKeysKeccak() {
+        return Stream.of(
+            Arguments.of(
+                "c5f54ba980fcbb657dbaaa42700539b207873e134d2375efeab5f1ab52f87844",
+                NetworkType.MIJIN,
+                "MDD2CT6LQLIYQ56KIXI3ENTM6EK3D44P5LDT7JHT"),
+            Arguments.of(
+                "c5f54ba980fcbb657dbaaa42700539b207873e134d2375efeab5f1ab52f87844",
+                NetworkType.MIJIN,
+                "MDD2CT6LQLIYQ56KIXI3ENTM6EK3D44P5LDT7JHT"),
+            Arguments.of(
+                "c5f54ba980fcbb657dbaaa42700539b207873e134d2375efeab5f1ab52f87844",
+                NetworkType.TEST_NET,
+                "TDD2CT6LQLIYQ56KIXI3ENTM6EK3D44P5KZPFMK2"),
+            Arguments.of(
+                "fbb91b16df828e21a9802980a44fc757c588bc1382a4cea429d6fa2ae0333f56",
+                NetworkType.MAIN_NET,
+                "NBAF3BFLLPWH33MYE6VUPP5T6DQBZBKIDEQKZQOE"),
+            Arguments.of(
+                "fbb91b16df828e21a9802980a44fc757c588bc1382a4cea429d6fa2ae0333f56",
+                NetworkType.TEST_NET,
+                "TBAF3BFLLPWH33MYE6VUPP5T6DQBZBKIDGA56VWB"),
+            Arguments.of(
+                "fbb91b16df828e21a9802980a44fc757c588bc1382a4cea429d6fa2ae0333f56",
+                NetworkType.MIJIN,
+                "MBAF3BFLLPWH33MYE6VUPP5T6DQBZBKIDEBBSGE2"),
+            Arguments.of(
+                "6d34c04f3a0e42f0c3c6f50e475ae018cfa2f56df58c481ad4300424a6270cbb",
+                NetworkType.MAIN_NET,
+                "NA5IG3XFXZHIPJ5QLKX2FBJPEZYPMBPPK2ZRC3EH"));
     }
 
     @Test
@@ -143,12 +177,13 @@ class AddressTest {
             }).getMessage());
     }
 
-    @Test
-    void createShouldFailWhenInvalidPublicKey() {
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    void createShouldFailWhenInvalidPublicKey(SignSchema signSchema) {
         Assertions.assertEquals("Public key is not valid", assertThrows(
             IllegalArgumentException.class,
             () -> {
-                Address.createFromPublicKey("InvalidPublicKey", NetworkType.MIJIN);
+                Address.createFromPublicKey("InvalidPublicKey", NetworkType.MIJIN, signSchema);
             }).getMessage());
     }
 
@@ -161,10 +196,21 @@ class AddressTest {
     }
 
     @ParameterizedTest
-    @MethodSource("publicKeys")
+    @MethodSource("publicKeysSha3")
     @DisplayName("AddressFromPublicKey")
-    void testCreateAddressFromPublicKey(String publicKey, NetworkType networkType, String input) {
-        Address address = Address.createFromPublicKey(publicKey, networkType);
+    void testCreateAddressFromPublicKeySha3(String publicKey, NetworkType networkType,
+        String input) {
+        Address address = Address.createFromPublicKey(publicKey, networkType, SignSchema.SHA3);
+        assertEquals(input, address.plain());
+    }
+
+    @ParameterizedTest
+    @MethodSource("publicKeysKeccak")
+    @DisplayName("AddressFromPublicKey")
+    void testCreateAddressFromPublicKeyKeccak(String publicKey, NetworkType networkType,
+        String input) {
+        Address address = Address
+            .createFromPublicKey(publicKey, networkType, SignSchema.KECCAK_REVERSED_KEY);
         assertEquals(input, address.plain());
     }
 }

--- a/sdk-core/src/test/java/io/nem/sdk/model/account/MultisigAccountGraphInfoTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/account/MultisigAccountGraphInfoTest.java
@@ -18,6 +18,7 @@ package io.nem.sdk.model.account;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,23 +27,26 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class MultisigAccountGraphInfoTest {
 
-    @Test
-    void returnTheLevels() {
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    void returnTheLevels(SignSchema signSchema) {
         Map<Integer, List<MultisigAccountInfo>> info = new HashMap<>();
         MultisigAccountInfo multisigAccountInfo =
             new MultisigAccountInfo(
                 new PublicAccount(
                     "5D58EC16F07BF00BDE9B040E7451A37F9908C59E143A01438C04345D8E9DDF39",
-                    NetworkType.MIJIN_TEST),
+                    NetworkType.MIJIN_TEST, signSchema),
                 1,
                 1,
                 Collections.singletonList(
                     new PublicAccount(
                         "1674016C27FE2C2EB5DFA73996FA54A183B38AED0AA64F756A3918BAF08E061B",
-                        NetworkType.MIJIN_TEST)),
+                        NetworkType.MIJIN_TEST, signSchema)),
                 Collections.EMPTY_LIST);
         info.put(-3, Collections.singletonList(multisigAccountInfo));
         MultisigAccountGraphInfo multisigAccountGraphInfo = new MultisigAccountGraphInfo(info);

--- a/sdk-core/src/test/java/io/nem/sdk/model/account/MultisigAccountInfoTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/account/MultisigAccountInfoTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,22 +28,23 @@ import org.junit.jupiter.api.Test;
 
 class MultisigAccountInfoTest {
 
+    private SignSchema signSchema = SignSchema.DEFAULT;
     private final PublicAccount account1 =
         new PublicAccount(
             "b4f12e7c9f6946091e2cb8b6d3a12b50d17ccbbf646386ea27ce2946a7423dcf",
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, signSchema);
     private final PublicAccount account2 =
         new PublicAccount(
             "846b4439154579a5903b1459c9cf69cb8153f6d0110a7a0ed61de29ae4810bf2",
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, signSchema);
     private final PublicAccount account3 =
         new PublicAccount(
             "cf893ffcc47c33e7f68ab1db56365c156b0736824a0c1e273f9e00b8df8f01eb",
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, signSchema);
     private final PublicAccount account4 =
         new PublicAccount(
             "68b3fbb18729c1fde225c57f8ce080fa828f0067e451a3fd81fa628842b0b763",
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, signSchema);
 
     @Test
     void shouldBeCreated() {

--- a/sdk-core/src/test/java/io/nem/sdk/model/account/PublicAccountTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/account/PublicAccountTest.java
@@ -19,80 +19,116 @@ package io.nem.sdk.model.account;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.blockchain.NetworkType;
+import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class PublicAccountTest {
 
-    private String plain = "SAKQRU2RTNWMBE3KAQRTA46T3EB6DX567FO4EBFL";
-    private String pretty = "SAKQRU-2RTNWM-BE3KAQ-RTA46T-3EB6DX-567FO4-EBFL";
-    private String encoded = "901508D3519B6CC0936A04233073D3D903E1DFBEF95DC204AB";
+    private Map<SignSchema, String> plain;
+    private Map<SignSchema, String> pretty;
+    private Map<SignSchema, String> encoded;
     private String publicKey = "089E931203F63EECF695DB94957B03E1A6B7941532069B687386D6D4A7B6BE4A";
     private NetworkType networkType = NetworkType.MIJIN_TEST;
 
-    @Test
-    void shouldCreatePublicAccountViaConstructor() {
-        PublicAccount publicAccount = new PublicAccount(publicKey, NetworkType.MIJIN_TEST);
+    @BeforeEach
+    private void setUp() {
+        plain = new EnumMap<>(SignSchema.class);
+        plain.put(SignSchema.SHA3, "SAKQRU2RTNWMBE3KAQRTA46T3EB6DX567FO4EBFL");
+        plain.put(SignSchema.KECCAK_REVERSED_KEY, "SBCUJZNUSWU4FWRYDUPJO5IBOEJ5CI2AEMLBPT6V");
+
+        pretty = new EnumMap<>(SignSchema.class);
+        pretty.put(SignSchema.SHA3, "SAKQRU-2RTNWM-BE3KAQ-RTA46T-3EB6DX-567FO4-EBFL");
+        pretty
+            .put(SignSchema.KECCAK_REVERSED_KEY, "SBCUJZ-NUSWU4-FWRYDU-PJO5IB-OEJ5CI-2AEMLB-PT6V");
+
+        encoded = new EnumMap<>(SignSchema.class);
+        encoded.put(SignSchema.SHA3, "901508D3519B6CC0936A04233073D3D903E1DFBEF95DC204AB");
+        encoded
+            .put(SignSchema.KECCAK_REVERSED_KEY,
+                "904544e5b495a9c2da381d1e9775017113d12340231617cfd5");
+    }
+
+
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    void shouldCreatePublicAccountViaConstructor(SignSchema signSchema) {
+        PublicAccount publicAccount = new PublicAccount(publicKey, NetworkType.MIJIN_TEST,
+            signSchema);
         assertEquals(publicKey.toUpperCase(), publicAccount.getPublicKey().toString());
-        assertEquals(plain,
+        assertEquals(plain.get(signSchema),
             publicAccount.getAddress().plain());
     }
 
-    @Test
-    void shouldCreatePublicAccountViaStaticConstructor() {
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    void shouldCreatePublicAccountViaStaticConstructor(SignSchema signSchema) {
         PublicAccount publicAccount =
-            PublicAccount.createFromPublicKey(publicKey, NetworkType.MIJIN_TEST);
+            PublicAccount
+                .createFromPublicKey(publicKey, NetworkType.MIJIN_TEST, signSchema);
         assertEquals(publicKey.toUpperCase(), publicAccount.getPublicKey().toString());
-        assertEquals(plain,
-            publicAccount.getAddress().plain());
+        assertEquals(plain.get(signSchema), publicAccount.getAddress().plain());
     }
 
-    @Test
-    void equalityIsBasedOnPublicKeyAndNetwork() {
-        PublicAccount publicAccount = new PublicAccount(publicKey, NetworkType.MIJIN_TEST);
-        PublicAccount publicAccount2 = new PublicAccount(publicKey, NetworkType.MIJIN_TEST);
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    void equalityIsBasedOnPublicKeyAndNetwork(SignSchema signSchema) {
+        PublicAccount publicAccount = new PublicAccount(publicKey, NetworkType.MIJIN_TEST,
+            signSchema);
+        PublicAccount publicAccount2 = new PublicAccount(publicKey, NetworkType.MIJIN_TEST,
+            signSchema);
         assertEquals(publicAccount, publicAccount2);
     }
 
-    @Test
-    void equalityReturnsFalseIfNetworkIsDifferent() {
-        PublicAccount publicAccount = new PublicAccount(publicKey, NetworkType.MIJIN_TEST);
-        PublicAccount publicAccount2 = new PublicAccount(publicKey, NetworkType.MAIN_NET);
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    void equalityReturnsFalseIfNetworkIsDifferent(SignSchema signSchema) {
+        PublicAccount publicAccount = new PublicAccount(publicKey, NetworkType.MIJIN_TEST,
+            signSchema);
+        PublicAccount publicAccount2 = new PublicAccount(publicKey, NetworkType.MAIN_NET,
+            signSchema);
         assertNotEquals(publicAccount, publicAccount2);
     }
 
-
-    @Test
-    public void testAddresses() {
-        assertAddress(Address.createFromRawAddress(plain));
-        assertAddress(Address.createFromRawAddress(pretty));
-        assertAddress(Address.createFromEncoded(encoded));
-        assertAddress(Address.createFromPublicKey(publicKey, networkType));
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    public void testAddresses(SignSchema signSchema) {
+        assertAddress(Address.createFromRawAddress(plain.get(signSchema)), signSchema);
+        assertAddress(Address.createFromRawAddress(pretty.get(signSchema)), signSchema);
+        assertAddress(Address.createFromEncoded(encoded.get(signSchema)), signSchema);
+        assertAddress(Address.createFromPublicKey(publicKey, networkType, signSchema), signSchema);
+        assertAddress(Address
+                .createFromEncoded(Address.createFromRawAddress(plain.get(signSchema)).encoded()),
+            signSchema);
     }
 
-    private void assertAddress(Address address) {
-        Assert.assertEquals(plain, address.plain());
-        Assert.assertEquals(pretty, address.pretty());
+    private void assertAddress(Address address, SignSchema signSchema) {
+        Assert.assertEquals(plain.get(signSchema), address.plain());
+        Assert.assertEquals(pretty.get(signSchema), address.pretty());
         Assert.assertEquals(networkType, address.getNetworkType());
     }
 
-
-    @Test
-    void shouldBeEquals() {
+    @ParameterizedTest
+    @EnumSource(SignSchema.class)
+    void shouldBeEquals(SignSchema signSchema) {
         PublicAccount account1 = PublicAccount.createFromPublicKey(
             "A5F82EC8EBB341427B6785C8111906CD0DF18838FB11B51CE0E18B5E79DFF630",
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, signSchema);
 
         PublicAccount account2 = PublicAccount.createFromPublicKey(
             "A5F82EC8EBB341427B6785C8111906CD0DF18838FB11B51CE0E18B5E79DFF630",
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, signSchema);
 
         PublicAccount account3 = PublicAccount.createFromPublicKey(
             "A5F82EC8EBB341427B6785C8111906CD0DF18838FB11B51CE0E18B5E79DFF630",
-            NetworkType.MAIN_NET);
+            NetworkType.MAIN_NET, signSchema);
 
         Assertions.assertEquals(account1, account2);
         Assertions.assertEquals(account1.hashCode(), account2.hashCode());

--- a/sdk-core/src/test/java/io/nem/sdk/model/blockchain/BlockInfoTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/blockchain/BlockInfoTest.java
@@ -18,11 +18,11 @@ package io.nem.sdk.model.blockchain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -60,6 +60,7 @@ class BlockInfoTest {
         beneficiaryPublicKey = "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF";
         blockInfo =
             BlockInfo.create(
+                SignSchema.DEFAULT,
                 hash,
                 generationHash,
                 BigInteger.ZERO,
@@ -87,8 +88,8 @@ class BlockInfoTest {
         assertEquals(BigInteger.valueOf(0), blockInfo.getTotalFee());
         assertEquals(new Integer(25), blockInfo.getNumTransactions());
         assertEquals(signature, blockInfo.getSignature());
-        Assertions.assertEquals(
-            new PublicAccount(signer, NetworkType.MIJIN_TEST), blockInfo.getSignerPublicAccount());
+        assertEquals(new PublicAccount(signer, NetworkType.MIJIN_TEST, SignSchema.DEFAULT),
+            blockInfo.getSignerPublicAccount());
         assertEquals(NetworkType.MIJIN_TEST, blockInfo.getNetworkType());
         assertEquals(3, (int) blockInfo.getVersion());
         assertEquals(32768, blockInfo.getType());
@@ -101,7 +102,7 @@ class BlockInfoTest {
         assertEquals(blockReceiptsHash, blockInfo.getBlockReceiptsHash());
         assertEquals(stateHash, blockInfo.getStateHash());
         assertEquals(
-            new PublicAccount(beneficiaryPublicKey, NetworkType.MIJIN_TEST),
+            new PublicAccount(beneficiaryPublicKey, NetworkType.MIJIN_TEST, SignSchema.DEFAULT),
             blockInfo.getBeneficiaryPublicAccount());
     }
 }

--- a/sdk-core/src/test/java/io/nem/sdk/model/mosaic/MosaicIdTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/mosaic/MosaicIdTest.java
@@ -20,12 +20,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
 
 class MosaicIdTest {
+
+    static SignSchema signSchema = SignSchema.DEFAULT;
 
     String publicKey = "b4f12e7c9f6946091e2cb8b6d3a12b50d17ccbbf646386ea27ce2946a7423dcf";
 
@@ -75,7 +78,8 @@ class MosaicIdTest {
 
     @Test
     void createAMosaicIdFromNonceAndOwner() {
-        PublicAccount owner = PublicAccount.createFromPublicKey(publicKey, NetworkType.MIJIN_TEST);
+        PublicAccount owner = PublicAccount.createFromPublicKey(publicKey, NetworkType.MIJIN_TEST,
+            signSchema);
         byte[] bytes = new byte[]{0x0, 0x0, 0x0, 0x0};
         MosaicNonce nonce = new MosaicNonce(bytes);
         MosaicId mosaicId = MosaicId.createFromNonce(nonce, owner);
@@ -85,7 +89,8 @@ class MosaicIdTest {
 
     @Test
     void createAMosaicIdFromNonceAndOwnerTwiceTheSame() {
-        PublicAccount owner = PublicAccount.createFromPublicKey(publicKey, NetworkType.MIJIN_TEST);
+        PublicAccount owner = PublicAccount.createFromPublicKey(publicKey, NetworkType.MIJIN_TEST,
+            signSchema);
         byte[] bytes = new byte[]{0x0, 0x0, 0x0, 0x0};
         MosaicNonce nonce = new MosaicNonce(bytes);
         MosaicId mosaicId1 = MosaicId.createFromNonce(nonce, owner);

--- a/sdk-core/src/test/java/io/nem/sdk/model/mosaic/MosaicInfoTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/mosaic/MosaicInfoTest.java
@@ -20,12 +20,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
 
 class MosaicInfoTest {
+    static SignSchema signSchema = SignSchema.DEFAULT;
+
 
     @Test
     void createAMosaicInfoViaConstructor() {
@@ -40,7 +43,7 @@ class MosaicInfoTest {
                 new BigInteger("0"),
                 new PublicAccount(
                     "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                    NetworkType.MIJIN_TEST),
+                    NetworkType.MIJIN_TEST, signSchema),
                 1,
                 mosaicProperties);
 
@@ -50,7 +53,7 @@ class MosaicInfoTest {
         assertEquals(
             new PublicAccount(
                 "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                NetworkType.MIJIN_TEST),
+                NetworkType.MIJIN_TEST, signSchema),
             mosaicInfo.getOwner());
         assertTrue(mosaicInfo.isSupplyMutable());
         assertTrue(mosaicInfo.isTransferable());
@@ -70,7 +73,7 @@ class MosaicInfoTest {
                 new BigInteger("0"),
                 new PublicAccount(
                     "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                    NetworkType.MIJIN_TEST),
+                    NetworkType.MIJIN_TEST, signSchema),
                 1,
                 mosaicProperties);
 
@@ -89,7 +92,7 @@ class MosaicInfoTest {
                 new BigInteger("0"),
                 new PublicAccount(
                     "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                    NetworkType.MIJIN_TEST),
+                    NetworkType.MIJIN_TEST, signSchema),
                 1,
                 mosaicProperties);
 
@@ -108,7 +111,7 @@ class MosaicInfoTest {
                 new BigInteger("0"),
                 new PublicAccount(
                     "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                    NetworkType.MIJIN_TEST),
+                    NetworkType.MIJIN_TEST, signSchema),
                 1,
                 mosaicProperties);
 
@@ -127,7 +130,7 @@ class MosaicInfoTest {
                 new BigInteger("0"),
                 new PublicAccount(
                     "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                    NetworkType.MIJIN_TEST),
+                    NetworkType.MIJIN_TEST, signSchema),
                 1,
                 mosaicProperties);
 

--- a/sdk-core/src/test/java/io/nem/sdk/model/namespace/NamespaceInfoTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/namespace/NamespaceInfoTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.mosaic.MosaicId;
@@ -31,6 +32,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class NamespaceInfoTest {
+
+    static SignSchema signSchema = SignSchema.DEFAULT;
 
     @Test
     void createANamespaceInfoViaConstructor() {
@@ -46,7 +49,7 @@ class NamespaceInfoTest {
                 NamespaceId.createFromId(new BigInteger("0")),
                 new PublicAccount(
                     "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                    NetworkType.MIJIN_TEST),
+                    NetworkType.MIJIN_TEST, signSchema),
                 new BigInteger("1"),
                 new BigInteger("-1"),
                 new MosaicAlias(new MosaicId(new BigInteger("100"))));
@@ -60,7 +63,7 @@ class NamespaceInfoTest {
         Assertions.assertEquals(
             new PublicAccount(
                 "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                NetworkType.MIJIN_TEST),
+                NetworkType.MIJIN_TEST, signSchema),
             namespaceInfo.getOwner());
         assertEquals(new BigInteger("1"), namespaceInfo.getStartHeight());
         assertEquals(new BigInteger("-1"), namespaceInfo.getEndHeight());
@@ -135,7 +138,7 @@ class NamespaceInfoTest {
             NamespaceId.createFromId(new BigInteger("0")),
             new PublicAccount(
                 "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                NetworkType.MIJIN_TEST),
+                NetworkType.MIJIN_TEST, signSchema),
             new BigInteger("1"),
             new BigInteger("-1"),
             new MosaicAlias(new MosaicId(new BigInteger("100"))));
@@ -154,7 +157,7 @@ class NamespaceInfoTest {
             NamespaceId.createFromId(new BigInteger("-3087871471161192663")),
             new PublicAccount(
                 "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                NetworkType.MIJIN_TEST),
+                NetworkType.MIJIN_TEST, signSchema),
             new BigInteger("1"),
             new BigInteger("-1"),
             new MosaicAlias(new MosaicId(new BigInteger("100"))));

--- a/sdk-core/src/test/java/io/nem/sdk/model/node/NodeInfoTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/node/NodeInfoTest.java
@@ -18,12 +18,15 @@ package io.nem.sdk.model.node;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.blockchain.NetworkType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class NodeInfoTest {
+
+    static SignSchema signSchema = SignSchema.DEFAULT;
 
     static Account account;
 
@@ -32,7 +35,7 @@ public class NodeInfoTest {
         account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
     }
 
     @Test

--- a/sdk-core/src/test/java/io/nem/sdk/model/node/NodeTimeTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/node/NodeTimeTest.java
@@ -18,6 +18,7 @@ package io.nem.sdk.model.node;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.math.BigInteger;
@@ -26,6 +27,8 @@ import org.junit.jupiter.api.Test;
 
 public class NodeTimeTest {
 
+    static SignSchema signSchema = SignSchema.DEFAULT;
+
     static Account account;
 
     @BeforeAll
@@ -33,7 +36,7 @@ public class NodeTimeTest {
         account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
     }
 
     @Test

--- a/sdk-core/src/test/java/io/nem/sdk/model/receipt/BalanceChangeReceiptTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/receipt/BalanceChangeReceiptTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.mosaic.MosaicId;
@@ -36,12 +37,14 @@ public class BalanceChangeReceiptTest {
 
     private MosaicId mosaicId;
 
+    static SignSchema signSchema = SignSchema.DEFAULT;
+
     @BeforeAll
     public void setup() {
         account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         mosaicId = new MosaicId("85BBEA6CC462B244");
     }
 

--- a/sdk-core/src/test/java/io/nem/sdk/model/receipt/BalanceTransferReceiptTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/receipt/BalanceTransferReceiptTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -35,13 +36,14 @@ public class BalanceTransferReceiptTest {
     static MosaicId mosaicId;
     static Address recipientAddress;
     static AddressAlias recipientAddressAlias;
+    static SignSchema signSchema = SignSchema.DEFAULT;
 
     @BeforeAll
     public static void setup() {
         account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         mosaicId = new MosaicId("85BBEA6CC462B244");
         recipientAddress =
             new Address("SDGLFW-DSHILT-IUHGIB-H5UGX2-VYF5VN-JEKCCD-BR26", NetworkType.MIJIN_TEST);

--- a/sdk-core/src/test/java/io/nem/sdk/model/receipt/TransactionStatementTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/receipt/TransactionStatementTest.java
@@ -18,6 +18,7 @@ package io.nem.sdk.model.receipt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -32,14 +33,14 @@ public class TransactionStatementTest {
 
     static List<Receipt> receipts;
     static ReceiptSource receiptSource;
-
+    static SignSchema signSchema = SignSchema.DEFAULT;
     @BeforeAll
     public static void setup() {
         receiptSource = new ReceiptSource(1, 1);
         Account account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         MosaicId mosaicId = new MosaicId("85BBEA6CC462B244");
         Address recipientAddress =
             new Address("SDGLFW-DSHILT-IUHGIB-H5UGX2-VYF5VN-JEKCCD-BR26", NetworkType.MIJIN_TEST);

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/AccountLinkTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/AccountLinkTransactionTest.java
@@ -18,6 +18,7 @@ package io.nem.sdk.model.transaction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.math.BigInteger;
@@ -33,7 +34,7 @@ public class AccountLinkTransactionTest {
         account =
             new Account(
                 "041e2ce90c31cd65620ed16ab7a5a485e5b335d7e61c75cd9b3a2fed3e091728",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, SignSchema.DEFAULT);
     }
 
     @Test

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/AddressAliasTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/AddressAliasTransactionTest.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.model.transaction;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.HexEncoder;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class AddressAliasTransactionTest {
-
+    private static SignSchema signSchema = SignSchema.DEFAULT;
     @Test
     void shouldSerialize() {
 
@@ -40,7 +41,7 @@ public class AddressAliasTransactionTest {
         NamespaceId namespaceId = NamespaceId.createFromId(new BigInteger("-8884663987180930485"));
         PublicAccount signature = PublicAccount.createFromPublicKey(
             "68b3fbb18729c1fde225c57f8ce080fa828f0067e451a3fd81fa628842b0b763",
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, signSchema);
         TransactionInfo transactionInfo =
             TransactionInfo.createAggregate(
                 new BigInteger("121855"),

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/AggregateTransactionCosignatureTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/AggregateTransactionCosignatureTest.java
@@ -18,12 +18,14 @@ package io.nem.sdk.model.transaction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import org.junit.jupiter.api.Test;
 
 public class AggregateTransactionCosignatureTest {
 
+    private static SignSchema signSchema = SignSchema.DEFAULT;
     @Test
     void createAnAggregateCosignatureViaConstructor() {
         AggregateTransactionCosignature aggregateTransactionCosignature =
@@ -31,13 +33,13 @@ public class AggregateTransactionCosignatureTest {
                 "signature",
                 new PublicAccount(
                     "9A49366406ACA952B88BADF5F1E9BE6CE4968141035A60BE503273EA65456B24",
-                    NetworkType.MIJIN_TEST));
+                    NetworkType.MIJIN_TEST, signSchema));
 
         assertEquals("signature", aggregateTransactionCosignature.getSignature());
         assertEquals(
             new PublicAccount(
                 "9A49366406ACA952B88BADF5F1E9BE6CE4968141035A60BE503273EA65456B24",
-                NetworkType.MIJIN_TEST),
+                NetworkType.MIJIN_TEST, signSchema),
             aggregateTransactionCosignature.getSigner());
     }
 }

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/HashLockTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/HashLockTransactionTest.java
@@ -19,6 +19,7 @@ package io.nem.sdk.model.transaction;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.HexEncoder;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.account.PublicAccount;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 class HashLockTransactionTest {
 
+    private static SignSchema signSchema = SignSchema.DEFAULT;
     static Account account;
     static String generationHash;
 
@@ -39,7 +41,7 @@ class HashLockTransactionTest {
         account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         generationHash = "57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6";
     }
 
@@ -87,7 +89,7 @@ class HashLockTransactionTest {
                 .toAggregate(
                     new PublicAccount(
                         "9A49366406ACA952B88BADF5F1E9BE6CE4968141035A60BE503273EA65456B24",
-                        NetworkType.MIJIN_TEST))
+                        NetworkType.MIJIN_TEST, signSchema))
                 .toAggregateTransactionBytes();
         assertEquals(expected, HexEncoder.getString(actual));
     }

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/MosaicDefinitionTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/MosaicDefinitionTransactionTest.java
@@ -19,6 +19,7 @@ package io.nem.sdk.model.transaction;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.mosaic.MosaicId;
@@ -32,6 +33,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MosaicDefinitionTransactionTest {
+
+    static SignSchema signSchema = SignSchema.DEFAULT;
 
     @Test
     void createAMosaicCreationTransactionViaStaticConstructor() {
@@ -92,7 +95,7 @@ class MosaicDefinitionTransactionTest {
 
         PublicAccount signature = PublicAccount.createFromPublicKey(
             "68b3fbb18729c1fde225c57f8ce080fa828f0067e451a3fd81fa628842b0b763",
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, signSchema);
         TransactionInfo transactionInfo =
             TransactionInfo.createAggregate(
                 new BigInteger("121855"),

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/MultisigAccountModificationTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/MultisigAccountModificationTransactionTest.java
@@ -19,6 +19,7 @@ package io.nem.sdk.model.transaction;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.math.BigInteger;
@@ -32,6 +33,8 @@ import org.junit.jupiter.api.Test;
 
 class MultisigAccountModificationTransactionTest {
 
+    static SignSchema signSchema = SignSchema.DEFAULT;
+
     @Test
     void createAMultisigModificationTransactionViaConstructor() {
         MultisigAccountModificationTransaction multisigAccountModificationTransaction =
@@ -44,7 +47,7 @@ class MultisigAccountModificationTransactionTest {
                         MultisigCosignatoryModificationType.ADD,
                         PublicAccount.createFromPublicKey(
                             "68b3fbb18729c1fde225c57f8ce080fa828f0067e451a3fd81fa628842b0b763",
-                            NetworkType.MIJIN_TEST))),
+                            NetworkType.MIJIN_TEST, signSchema))),
                 NetworkType.MIJIN_TEST);
 
         assertEquals(NetworkType.MIJIN_TEST, multisigAccountModificationTransaction.getNetworkType());
@@ -85,12 +88,12 @@ class MultisigAccountModificationTransactionTest {
                         MultisigCosignatoryModificationType.ADD,
                         PublicAccount.createFromPublicKey(
                             "68b3fbb18729c1fde225c57f8ce080fa828f0067e451a3fd81fa628842b0b763",
-                            NetworkType.MIJIN_TEST)),
+                            NetworkType.MIJIN_TEST, signSchema)),
                     new MultisigCosignatoryModification(
                         MultisigCosignatoryModificationType.ADD,
                         PublicAccount.createFromPublicKey(
                             "cf893ffcc47c33e7f68ab1db56365c156b0736824a0c1e273f9e00b8df8f01eb",
-                            NetworkType.MIJIN_TEST))),
+                            NetworkType.MIJIN_TEST, signSchema))),
                 NetworkType.MIJIN_TEST);
 
         byte[] actual = multisigAccountModificationTransaction.generateBytes();

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/NamespaceRegistrationTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/NamespaceRegistrationTransactionTest.java
@@ -19,6 +19,7 @@ package io.nem.sdk.model.transaction;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.HexEncoder;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -33,10 +34,12 @@ import org.junit.jupiter.api.Test;
 
 class NamespaceRegistrationTransactionTest {
 
+    static SignSchema signSchema = SignSchema.DEFAULT;
+
     private final String publicKey =
         "b4f12e7c9f6946091e2cb8b6d3a12b50d17ccbbf646386ea27ce2946a7423dcf";
     private final Account testAccount =
-        Account.createFromPrivateKey(publicKey, NetworkType.MIJIN_TEST);
+        Account.createFromPrivateKey(publicKey, NetworkType.MIJIN_TEST, signSchema);
     private final String generationHash =
         "57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6";
 

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/SecretLockTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/SecretLockTransactionTest.java
@@ -19,6 +19,7 @@ package io.nem.sdk.model.transaction;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.account.PublicAccount;
@@ -40,7 +41,7 @@ public class SecretLockTransactionTest {
         account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, SignSchema.DEFAULT);
         generationHash = "57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6";
     }
 
@@ -85,7 +86,7 @@ public class SecretLockTransactionTest {
                 .toAggregate(
                     new PublicAccount(
                         "9A49366406ACA952B88BADF5F1E9BE6CE4968141035A60BE503273EA65456B24",
-                        NetworkType.MIJIN_TEST))
+                        NetworkType.MIJIN_TEST, SignSchema.DEFAULT))
                 .toAggregateTransactionBytes();
         assertEquals(expected, Hex.toHexString(actual));
     }
@@ -104,7 +105,8 @@ public class SecretLockTransactionTest {
                 NetworkType.MIJIN_TEST);
         SignedTransaction signedTransaction = secretLocktx.signWith(account, generationHash);
         String payload = signedTransaction.getPayload();
-        assertEquals("44B262C46CEABB8580969800000000006400000000000000003FC8BA10229AB5778D05D9C4B7F56676A88B"
+        assertEquals(
+            "44B262C46CEABB8580969800000000006400000000000000003FC8BA10229AB5778D05D9C4B7F56676A88B"
                 + "F9295C185ACFC0F961DB5408CAFE90E8FEBD671DD41BEE94EC3BA5831CB608A312C2F203BA84AC",
             payload.substring(240));
         assertEquals(

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/SecretProofTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/SecretProofTransactionTest.java
@@ -19,6 +19,7 @@ package io.nem.sdk.model.transaction;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.account.PublicAccount;
@@ -31,6 +32,8 @@ import org.junit.jupiter.api.Test;
 
 public class SecretProofTransactionTest {
 
+    static SignSchema signSchema = SignSchema.DEFAULT;
+
     static Account account;
     static String generationHash;
     static Address recipient;
@@ -40,12 +43,12 @@ public class SecretProofTransactionTest {
         account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         generationHash = "57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6";
         recipient =
             Address.createFromPublicKey(
                 "b4f12e7c9f6946091e2cb8b6d3a12b50d17ccbbf646386ea27ce2946a7423dcf",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
     }
 
     @Test
@@ -92,7 +95,7 @@ public class SecretProofTransactionTest {
                 .toAggregate(
                     new PublicAccount(
                         "9A49366406ACA952B88BADF5F1E9BE6CE4968141035A60BE503273EA65456B24",
-                        NetworkType.MIJIN_TEST))
+                        NetworkType.MIJIN_TEST, signSchema))
                 .toAggregateTransactionBytes();
         assertEquals(expected, Hex.toHexString(actual));
     }

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/TransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/TransactionTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import java.math.BigInteger;
@@ -27,10 +28,12 @@ import org.junit.jupiter.api.Test;
 
 public class TransactionTest {
 
+    static SignSchema signSchema = SignSchema.DEFAULT;
+
     private final PublicAccount signer =
         PublicAccount.createFromPublicKey(
             "b4f12e7c9f6946091e2cb8b6d3a12b50d17ccbbf646386ea27ce2946a7423dcf",
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, signSchema);
     private final String generationHash =
         "57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6";
 

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/TransferTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/TransferTransactionTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.account.PublicAccount;
@@ -37,6 +38,8 @@ import org.junit.jupiter.api.Test;
 
 class TransferTransactionTest {
 
+    static SignSchema signSchema = SignSchema.DEFAULT;
+
     static Account account;
     static String generationHash;
 
@@ -45,7 +48,7 @@ class TransferTransactionTest {
         account =
             new Account(
                 "787225aaff3d2c71f4ffa32d4f19ec4922f3cd869747f267378f81f8e3fcb12d",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         generationHash = "57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6";
     }
 
@@ -114,7 +117,7 @@ class TransferTransactionTest {
                 .toAggregate(
                     new PublicAccount(
                         "9A49366406ACA952B88BADF5F1E9BE6CE4968141035A60BE503273EA65456B24",
-                        NetworkType.MIJIN_TEST))
+                        NetworkType.MIJIN_TEST, signSchema))
                 .toAggregateTransactionBytes();
         assertEquals(expected, Hex.toHexString(actual));
     }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/AbstractRepositoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/AbstractRepositoryOkHttpImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.okhttp;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.Suppliers;
 import io.nem.sdk.api.QueryParams;
 import io.nem.sdk.api.RepositoryCallException;
@@ -46,11 +47,14 @@ public abstract class AbstractRepositoryOkHttpImpl {
 
     private final JsonHelper jsonHelper;
 
-    public AbstractRepositoryOkHttpImpl(ApiClient apiClient) {
+    private final SignSchema signSchema;
+
+    public AbstractRepositoryOkHttpImpl(ApiClient apiClient, SignSchema signSchema) {
         networkTypeObservable = Suppliers
-            .memoize(() -> new NetworkRepositoryOkHttpImpl(apiClient).getNetworkType().cache());
+            .memoize(() -> new NetworkRepositoryOkHttpImpl(apiClient, signSchema).getNetworkType().cache());
         jsonHelper = new JsonHelperGson(apiClient.getJSON().getGson());
 
+        this.signSchema = signSchema;
     }
 
     public <T> Observable<T> call(Callable<T> callback) {
@@ -114,8 +118,11 @@ public abstract class AbstractRepositoryOkHttpImpl {
         return queryParams.map(QueryParams::getId).orElse(null);
     }
 
-
     public JsonHelper getJsonHelper() {
         return jsonHelper;
+    }
+
+    public SignSchema getSignSchema() {
+        return signSchema;
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/AccountRepositoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/AccountRepositoryOkHttpImpl.java
@@ -20,6 +20,7 @@ import static io.nem.core.utils.MapperUtils.toAddress;
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
 import io.nem.core.crypto.PublicKey;
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.AccountRepository;
 import io.nem.sdk.api.QueryParams;
 import io.nem.sdk.infrastructure.okhttp.mappers.GeneralTransactionMapper;
@@ -70,10 +71,10 @@ public class AccountRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImpl im
 
     private final TransactionMapper transactionMapper;
 
-    public AccountRepositoryOkHttpImpl(ApiClient apiClient) {
-        super(apiClient);
+    public AccountRepositoryOkHttpImpl(ApiClient apiClient, SignSchema signSchema) {
+        super(apiClient, signSchema);
         this.client = new AccountRoutesApi(apiClient);
-        this.transactionMapper = new GeneralTransactionMapper(getJsonHelper());
+        this.transactionMapper = new GeneralTransactionMapper(getJsonHelper(), signSchema);
     }
 
     private String getAddressEncoded(String address) throws DecoderException {
@@ -322,14 +323,15 @@ public class AccountRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImpl im
         NetworkType networkType = getNetworkTypeBlocking();
         return new MultisigAccountInfo(
             new PublicAccount(
-                dto.getAccountPublicKey(), networkType),
+                dto.getAccountPublicKey(), networkType, getSignSchema()),
             dto.getMinApproval(),
             dto.getMinRemoval(),
             dto.getCosignatoryPublicKeys().stream()
-                .map(cosigner -> new PublicAccount(cosigner, networkType))
+                .map(cosigner -> new PublicAccount(cosigner, networkType, getSignSchema()))
                 .collect(Collectors.toList()),
             dto.getMultisigPublicKeys().stream()
-                .map(multisigAccount -> new PublicAccount(multisigAccount, networkType))
+                .map(multisigAccount -> new PublicAccount(multisigAccount, networkType,
+                    getSignSchema()))
                 .collect(Collectors.toList()));
     }
 

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/ChainRepositoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/ChainRepositoryOkHttpImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.okhttp;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.ChainRepository;
 import io.nem.sdk.model.blockchain.BlockchainScore;
 import io.nem.sdk.openapi.okhttp_gson.api.ChainRoutesApi;
@@ -34,8 +35,8 @@ public class ChainRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImpl impl
 
     private final ChainRoutesApi client;
 
-    public ChainRepositoryOkHttpImpl(ApiClient apiClient) {
-        super(apiClient);
+    public ChainRepositoryOkHttpImpl(ApiClient apiClient, SignSchema signSchema) {
+        super(apiClient, signSchema);
         client = new ChainRoutesApi(apiClient);
     }
 

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/CollectionAdapter.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/CollectionAdapter.java
@@ -24,7 +24,10 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 
 /**
- * Created by fernando on 06/08/19.
+ * The open api generates objects where the array fields are empty initialized. When these objects
+ * are serialized back to json, those empty fields should be excluded
+ *
+ * This adapter exclude emtpy array fields to be serialized.
  *
  * @author Fernando Boucquez
  */

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/DiagnosticRepositoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/DiagnosticRepositoryOkHttpImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.okhttp;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.DiagnosticRepository;
 import io.nem.sdk.model.blockchain.BlockchainStorageInfo;
 import io.nem.sdk.model.blockchain.ServerInfo;
@@ -35,8 +36,8 @@ public class DiagnosticRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImpl
 
     private final DiagnosticRoutesApi client;
 
-    public DiagnosticRepositoryOkHttpImpl(ApiClient apiClient) {
-        super(apiClient);
+    public DiagnosticRepositoryOkHttpImpl(ApiClient apiClient, SignSchema signSchema) {
+        super(apiClient, signSchema);
         client = new DiagnosticRoutesApi(apiClient);
     }
 

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/ListenerOkHttp.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/ListenerOkHttp.java
@@ -17,6 +17,7 @@
 package io.nem.sdk.infrastructure.okhttp;
 
 import com.google.gson.JsonObject;
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.infrastructure.Listener;
 import io.nem.sdk.infrastructure.ListenerBase;
 import io.nem.sdk.infrastructure.ListenerChannel;
@@ -57,14 +58,14 @@ public class ListenerOkHttp extends ListenerBase implements Listener {
 
     private final TransactionMapper transactionMapper;
 
+    private final SignSchema signSchema;
+
     private WebSocket webSocket;
 
     private String uid;
 
-    /**
-     * @param url nis host
-     */
-    public ListenerOkHttp(OkHttpClient httpClient, String url, JSON json) {
+
+    public ListenerOkHttp(OkHttpClient httpClient, String url, JSON json, SignSchema signSchema) {
         try {
             this.url = new URL(url);
         } catch (MalformedURLException e) {
@@ -73,7 +74,8 @@ public class ListenerOkHttp extends ListenerBase implements Listener {
         }
         this.httpClient = httpClient;
         this.jsonHelper = new JsonHelperGson(json.getGson());
-        this.transactionMapper = new GeneralTransactionMapper(jsonHelper);
+        this.transactionMapper = new GeneralTransactionMapper(jsonHelper, signSchema);
+        this.signSchema = signSchema;
     }
 
     /**
@@ -139,7 +141,7 @@ public class ListenerOkHttp extends ListenerBase implements Listener {
     }
 
     private BlockInfo toBlockInfo(BlockInfoDTO blockInfoDTO) {
-        return BlockRepositoryOkHttpImpl.toBlockInfo(blockInfoDTO);
+        return BlockRepositoryOkHttpImpl.toBlockInfo(signSchema, blockInfoDTO);
     }
 
     private Transaction toTransaction(TransactionInfoDTO transactionInfo) {

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/MosaicRepositoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/MosaicRepositoryOkHttpImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.okhttp;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.api.MosaicRepository;
 import io.nem.sdk.model.account.PublicAccount;
@@ -47,8 +48,8 @@ public class MosaicRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImpl imp
 
     private final MosaicRoutesApi client;
 
-    public MosaicRepositoryOkHttpImpl(ApiClient apiClient) {
-        super(apiClient);
+    public MosaicRepositoryOkHttpImpl(ApiClient apiClient, SignSchema signSchema) {
+        super(apiClient, signSchema);
         client = new MosaicRoutesApi(apiClient);
     }
 
@@ -112,7 +113,8 @@ public class MosaicRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImpl imp
             MapperUtils.toMosaicId(mosaicInfoDTO.getMosaic().getId()),
             mosaicInfoDTO.getMosaic().getSupply(),
             mosaicInfoDTO.getMosaic().getStartHeight(),
-            new PublicAccount(mosaicInfoDTO.getMosaic().getOwnerPublicKey(), networkType),
+            new PublicAccount(mosaicInfoDTO.getMosaic().getOwnerPublicKey(), networkType,
+                getSignSchema()),
             mosaicInfoDTO.getMosaic().getRevision(),
             extractMosaicProperties(mosaicInfoDTO.getMosaic().getProperties()));
     }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/NamespaceRepositoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/NamespaceRepositoryOkHttpImpl.java
@@ -18,6 +18,7 @@ package io.nem.sdk.infrastructure.okhttp;
 
 import static io.nem.core.utils.MapperUtils.toNamespaceId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.api.NamespaceRepository;
 import io.nem.sdk.api.QueryParams;
@@ -58,8 +59,8 @@ public class NamespaceRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImpl 
 
     private final NamespaceRoutesApi client;
 
-    public NamespaceRepositoryOkHttpImpl(ApiClient apiClient) {
-        super(apiClient);
+    public NamespaceRepositoryOkHttpImpl(ApiClient apiClient, SignSchema signSchema) {
+        super(apiClient, signSchema);
         client = new NamespaceRoutesApi(apiClient);
     }
 
@@ -196,7 +197,7 @@ public class NamespaceRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImpl 
             this.extractLevels(namespaceInfoDTO),
             toNamespaceId(namespaceInfoDTO.getNamespace().getParentId()),
             new PublicAccount(namespaceInfoDTO.getNamespace().getOwnerPublicKey(),
-                getNetworkTypeBlocking()),
+                getNetworkTypeBlocking(), getSignSchema()),
             namespaceInfoDTO.getNamespace().getStartHeight(),
             namespaceInfoDTO.getNamespace().getEndHeight(),
             this.extractAlias(namespaceInfoDTO.getNamespace()));

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/NetworkRepositoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/NetworkRepositoryOkHttpImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.okhttp;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.NetworkRepository;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.openapi.okhttp_gson.api.NetworkRoutesApi;
@@ -33,8 +34,8 @@ public class NetworkRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImpl im
 
     private final NetworkRoutesApi client;
 
-    public NetworkRepositoryOkHttpImpl(ApiClient apiClient) {
-        super(apiClient);
+    public NetworkRepositoryOkHttpImpl(ApiClient apiClient, SignSchema signSchema) {
+        super(apiClient, signSchema);
         client = new NetworkRoutesApi(apiClient);
     }
 

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/NodeRepositoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/NodeRepositoryOkHttpImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.okhttp;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.NodeRepository;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.node.NodeInfo;
@@ -37,8 +38,8 @@ public class NodeRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImpl imple
 
     private final NodeRoutesApi client;
 
-    public NodeRepositoryOkHttpImpl(ApiClient apiClient) {
-        super(apiClient);
+    public NodeRepositoryOkHttpImpl(ApiClient apiClient, SignSchema signSchema) {
+        super(apiClient, signSchema);
         client = new NodeRoutesApi(apiClient);
     }
 

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/ReceiptMappingOkHttp.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/ReceiptMappingOkHttp.java
@@ -20,6 +20,7 @@ import static io.nem.core.utils.MapperUtils.toAddress;
 import static io.nem.core.utils.MapperUtils.toAddressFromUnresolved;
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.account.PublicAccount;
@@ -55,9 +56,11 @@ import java.util.stream.Collectors;
 public class ReceiptMappingOkHttp {
 
     private final JsonHelper jsonHelper;
+    private final SignSchema signSchema;
 
-    public ReceiptMappingOkHttp(JsonHelper jsonHelper) {
+    public ReceiptMappingOkHttp(JsonHelper jsonHelper, SignSchema signSchema) {
         this.jsonHelper = jsonHelper;
+        this.signSchema = signSchema;
     }
 
     public Statement createStatementFromDto(StatementsDTO input, NetworkType networkType) {
@@ -169,7 +172,7 @@ public class ReceiptMappingOkHttp {
     public BalanceChangeReceipt createBalanceChangeReceipt(
         BalanceChangeReceiptDTO receipt, NetworkType networkType) {
         return new BalanceChangeReceipt(
-            PublicAccount.createFromPublicKey(receipt.getTargetPublicKey(), networkType),
+            PublicAccount.createFromPublicKey(receipt.getTargetPublicKey(), networkType, signSchema),
             new MosaicId(receipt.getMosaicId()),
             receipt.getAmount(),
             ReceiptType.rawValueOf(receipt.getType().getValue()),
@@ -179,7 +182,7 @@ public class ReceiptMappingOkHttp {
     public BalanceTransferReceipt<Address> createBalanceTransferRecipient(
         BalanceTransferReceiptDTO receipt, NetworkType networkType) {
         return new BalanceTransferReceipt<>(
-            PublicAccount.createFromPublicKey(receipt.getSenderPublicKey(), networkType),
+            PublicAccount.createFromPublicKey(receipt.getSenderPublicKey(), networkType, signSchema),
             MapperUtils.toAddressFromUnresolved(receipt.getRecipientAddress()),
             new MosaicId(receipt.getMosaicId()),
             receipt.getAmount(),

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/RepositoryFactoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/RepositoryFactoryOkHttpImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.okhttp;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.AccountRepository;
 import io.nem.sdk.api.BlockRepository;
 import io.nem.sdk.api.ChainRepository;
@@ -47,13 +48,26 @@ import org.threeten.bp.OffsetDateTime;
 
 public class RepositoryFactoryOkHttpImpl implements RepositoryFactory {
 
-
+    /**
+     * The low level open api generated client. The repositories use the client to perform the rest
+     * calls.
+     */
     private final ApiClient apiClient;
 
+    /**
+     * The base url of the Catapult server.
+     */
     private final String baseUrl;
 
-    public RepositoryFactoryOkHttpImpl(String baseUrl) {
+    /**
+     * The sign schema used to generate Addresses. At the moment the user needs to configure it or
+     * use the default. The server should provide how's the configuration.
+     */
+    private final SignSchema signSchema;
+
+    public RepositoryFactoryOkHttpImpl(String baseUrl, SignSchema signSchema) {
         this.baseUrl = baseUrl;
+        this.signSchema = signSchema;
         this.apiClient = new ApiClient();
         this.apiClient.setBasePath(baseUrl);
 
@@ -77,51 +91,52 @@ public class RepositoryFactoryOkHttpImpl implements RepositoryFactory {
 
     @Override
     public AccountRepository createAccountRepository() {
-        return new AccountRepositoryOkHttpImpl(apiClient);
+        return new AccountRepositoryOkHttpImpl(apiClient, signSchema);
     }
 
     @Override
     public BlockRepository createBlockRepository() {
-        return new BlockRepositoryOkHttpImpl(apiClient);
+        return new BlockRepositoryOkHttpImpl(apiClient, signSchema);
     }
 
     @Override
     public ChainRepository createChainRepository() {
-        return new ChainRepositoryOkHttpImpl(apiClient);
+        return new ChainRepositoryOkHttpImpl(apiClient, signSchema);
     }
 
     @Override
     public DiagnosticRepository createDiagnosticRepository() {
-        return new DiagnosticRepositoryOkHttpImpl(apiClient);
+        return new DiagnosticRepositoryOkHttpImpl(apiClient, signSchema);
     }
 
     @Override
     public MosaicRepository createMosaicRepository() {
-        return new MosaicRepositoryOkHttpImpl(apiClient);
+        return new MosaicRepositoryOkHttpImpl(apiClient, signSchema);
     }
 
     @Override
     public NamespaceRepository createNamespaceRepository() {
-        return new NamespaceRepositoryOkHttpImpl(apiClient);
+        return new NamespaceRepositoryOkHttpImpl(apiClient, signSchema);
     }
 
     @Override
     public NetworkRepository createNetworkRepository() {
-        return new NetworkRepositoryOkHttpImpl(apiClient);
+        return new NetworkRepositoryOkHttpImpl(apiClient, signSchema);
     }
 
     @Override
     public NodeRepository createNodeRepository() {
-        return new NodeRepositoryOkHttpImpl(apiClient);
+        return new NodeRepositoryOkHttpImpl(apiClient, signSchema);
     }
 
     @Override
     public TransactionRepository createTransactionRepository() {
-        return new TransactionRepositoryOkHttpImpl(apiClient);
+        return new TransactionRepositoryOkHttpImpl(apiClient, signSchema);
     }
 
     @Override
     public Listener createListener() {
-        return new ListenerOkHttp(apiClient.getHttpClient(), baseUrl, apiClient.getJSON());
+        return new ListenerOkHttp(apiClient.getHttpClient(), baseUrl, apiClient.getJSON(),
+            signSchema);
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/TransactionRepositoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/TransactionRepositoryOkHttpImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.okhttp;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.TransactionRepository;
 import io.nem.sdk.infrastructure.okhttp.mappers.GeneralTransactionMapper;
 import io.nem.sdk.model.transaction.CosignatureSignedTransaction;
@@ -48,10 +49,10 @@ public class TransactionRepositoryOkHttpImpl extends AbstractRepositoryOkHttpImp
     private final TransactionRoutesApi client;
     private final GeneralTransactionMapper transactionMapper;
 
-    public TransactionRepositoryOkHttpImpl(ApiClient apiClient) {
-        super(apiClient);
+    public TransactionRepositoryOkHttpImpl(ApiClient apiClient, SignSchema signSchema) {
+        super(apiClient, signSchema);
         this.client = new TransactionRoutesApi(apiClient);
-        this.transactionMapper = new GeneralTransactionMapper(getJsonHelper());
+        this.transactionMapper = new GeneralTransactionMapper(getJsonHelper(), signSchema);
     }
 
 

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/AbstractTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/AbstractTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.okhttp.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.transaction.JsonHelper;
 import io.nem.sdk.model.transaction.Transaction;
@@ -41,13 +42,16 @@ public abstract class AbstractTransactionMapper<T> implements TransactionMapper 
 
     private final JsonHelper jsonHelper;
 
-    private Class<T> transactionDtoClass;
+    private final Class<T> transactionDtoClass;
+
+    private final SignSchema signSchema;
 
     public AbstractTransactionMapper(JsonHelper jsonHelper, TransactionType transactionType,
-        Class<T> transactionDtoClass) {
+        Class<T> transactionDtoClass, SignSchema signSchema) {
         this.jsonHelper = jsonHelper;
         this.transactionType = transactionType;
         this.transactionDtoClass = transactionDtoClass;
+        this.signSchema = signSchema;
     }
 
     /**
@@ -127,5 +131,9 @@ public abstract class AbstractTransactionMapper<T> implements TransactionMapper 
     @Override
     public TransactionType getTransactionType() {
         return transactionType;
+    }
+
+    public SignSchema getSignSchema() {
+        return signSchema;
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/AccountLinkTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/AccountLinkTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.okhttp.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.transaction.AccountLinkAction;
@@ -31,8 +32,9 @@ import io.nem.sdk.openapi.okhttp_gson.model.AccountLinkTransactionDTO;
 class AccountLinkTransactionMapper extends AbstractTransactionMapper<AccountLinkTransactionDTO> {
 
 
-    public AccountLinkTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.ACCOUNT_LINK, AccountLinkTransactionDTO.class);
+    public AccountLinkTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
+        super(jsonHelper, TransactionType.ACCOUNT_LINK, AccountLinkTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -46,10 +48,10 @@ class AccountLinkTransactionMapper extends AbstractTransactionMapper<AccountLink
             deadline,
             transaction.getMaxFee(),
             PublicAccount
-                .createFromPublicKey(transaction.getRemotePublicKey(), networkType),
+                .createFromPublicKey(transaction.getRemotePublicKey(), networkType, getSignSchema()),
             AccountLinkAction.rawValueOf(transaction.getLinkAction().getValue()),
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/AddressAliasTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/AddressAliasTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.okhttp.mappers;
 
 import static io.nem.core.utils.MapperUtils.toAddressFromUnresolved;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -37,8 +38,10 @@ class AddressAliasTransactionMapper extends
     AbstractTransactionMapper<AddressAliasTransactionDTO> {
 
 
-    public AddressAliasTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.ADDRESS_ALIAS, AddressAliasTransactionDTO.class);
+    public AddressAliasTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
+        super(jsonHelper, TransactionType.ADDRESS_ALIAS, AddressAliasTransactionDTO.class,
+            signSchema);
     }
 
     @Override
@@ -58,7 +61,7 @@ class AddressAliasTransactionMapper extends
             namespaceId,
             toAddressFromUnresolved(transaction.getAddress()),
             Optional.ofNullable(transaction.getSignature()),
-            Optional.of(new PublicAccount(transaction.getSignerPublicKey(), networkType)),
+            Optional.of(new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema())),
             Optional.of(transactionInfo));
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/AggregateTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/AggregateTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.okhttp.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.transaction.AggregateTransaction;
@@ -40,8 +41,8 @@ class AggregateTransactionMapper extends
 
     public AggregateTransactionMapper(JsonHelper jsonHelper,
         TransactionType transactionType,
-        TransactionMapper transactionMapper) {
-        super(jsonHelper, transactionType, AggregateBondedTransactionDTO.class);
+        TransactionMapper transactionMapper, SignSchema signSchema) {
+        super(jsonHelper, transactionType, AggregateBondedTransactionDTO.class, signSchema);
         this.transactionMapper = transactionMapper;
     }
 
@@ -77,7 +78,7 @@ class AggregateTransactionMapper extends
                             new AggregateTransactionCosignature(
                                 aggregateCosignature.getSignature(),
                                 new PublicAccount(aggregateCosignature.getSignerPublicKey(),
-                                    networkType)))
+                                    networkType, getSignSchema())))
                     .collect(Collectors.toList());
         }
 
@@ -90,7 +91,7 @@ class AggregateTransactionMapper extends
             transactions,
             cosignatures,
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/GeneralTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/GeneralTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.okhttp.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.transaction.JsonHelper;
 import io.nem.sdk.model.transaction.Transaction;
 import io.nem.sdk.model.transaction.TransactionType;
@@ -36,23 +37,26 @@ public class GeneralTransactionMapper implements TransactionMapper {
 
     private Map<TransactionType, TransactionMapper> transactionMappers = new EnumMap<>(TransactionType.class);
 
-    public GeneralTransactionMapper(JsonHelper jsonHelper) {
+    public GeneralTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
         this.jsonHelper = jsonHelper;
-        register(new AccountLinkTransactionMapper(jsonHelper));
-        register(new AddressAliasTransactionMapper(jsonHelper));
-        register(new HashLockTransactionMapper(jsonHelper));
-        register(new MosaicAliasTransactionMapper(jsonHelper));
-        register(new MosaicDefinitionTransactionMapper(jsonHelper));
-        register(new MosaicSupplyChangeTransactionMapper(jsonHelper));
-        register(new MultisigAccountModificationTransactionMapper(jsonHelper));
-        register(new NamespaceRegistrationTransactionMapper(jsonHelper));
-        register(new SecretLockTransactionMapper(jsonHelper));
-        register(new SecretProofTransactionMapper(jsonHelper));
-        register(new TransferTransactionMapper(jsonHelper));
+        register(new AccountLinkTransactionMapper(jsonHelper, signSchema));
+        register(new AddressAliasTransactionMapper(jsonHelper, signSchema));
+        register(new HashLockTransactionMapper(jsonHelper, signSchema));
+        register(new MosaicAliasTransactionMapper(jsonHelper, signSchema));
+        register(new MosaicDefinitionTransactionMapper(jsonHelper, signSchema));
+        register(new MosaicSupplyChangeTransactionMapper(jsonHelper, signSchema));
+        register(new MultisigAccountModificationTransactionMapper(jsonHelper, signSchema));
+        register(new NamespaceRegistrationTransactionMapper(jsonHelper, signSchema));
+        register(new SecretLockTransactionMapper(jsonHelper, signSchema));
+        register(new SecretProofTransactionMapper(jsonHelper, signSchema));
+        register(new TransferTransactionMapper(jsonHelper, signSchema));
+
         register(
-            new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_BONDED, this));
+            new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_BONDED, this,
+                signSchema));
         register(
-            new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_COMPLETE, this));
+            new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_COMPLETE, this,
+                signSchema));
     }
 
     private void register(TransactionMapper mapper) {

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/HashLockTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/HashLockTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.okhttp.mappers;
 
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.mosaic.Mosaic;
@@ -33,8 +34,9 @@ import io.nem.sdk.openapi.okhttp_gson.model.HashLockTransactionDTO;
 
 class HashLockTransactionMapper extends AbstractTransactionMapper<HashLockTransactionDTO> {
 
-    public HashLockTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.LOCK, HashLockTransactionDTO.class);
+    public HashLockTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
+        super(jsonHelper, TransactionType.LOCK, HashLockTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -54,7 +56,7 @@ class HashLockTransactionMapper extends AbstractTransactionMapper<HashLockTransa
             new SignedTransaction("", transaction.getHash(),
                 TransactionType.AGGREGATE_BONDED),
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/MosaicAliasTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/MosaicAliasTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.okhttp.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -34,8 +35,9 @@ import java.util.Optional;
 class MosaicAliasTransactionMapper extends
     AbstractTransactionMapper<MosaicAliasTransactionDTO> {
 
-    public MosaicAliasTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.MOSAIC_ALIAS, MosaicAliasTransactionDTO.class);
+    public MosaicAliasTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
+        super(jsonHelper, TransactionType.MOSAIC_ALIAS, MosaicAliasTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -55,7 +57,7 @@ class MosaicAliasTransactionMapper extends
             namespaceId,
             MapperUtils.toMosaicId(transaction.getMosaicId()),
             Optional.ofNullable(transaction.getSignature()),
-            Optional.of(new PublicAccount(transaction.getSignerPublicKey(), networkType)),
+            Optional.of(new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema())),
             Optional.of(transactionInfo));
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/MosaicDefinitionTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/MosaicDefinitionTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.okhttp.mappers;
 
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.mosaic.MosaicNonce;
 import io.nem.sdk.model.mosaic.MosaicProperties;
@@ -33,8 +34,10 @@ import io.nem.sdk.openapi.okhttp_gson.model.MosaicDefinitionTransactionDTO;
 class MosaicDefinitionTransactionMapper extends
     AbstractTransactionMapper<MosaicDefinitionTransactionDTO> {
 
-    public MosaicDefinitionTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.MOSAIC_DEFINITION, MosaicDefinitionTransactionDTO.class);
+    public MosaicDefinitionTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
+        super(jsonHelper, TransactionType.MOSAIC_DEFINITION, MosaicDefinitionTransactionDTO.class,
+            signSchema);
     }
 
     @Override
@@ -64,7 +67,7 @@ class MosaicDefinitionTransactionMapper extends
             transaction.getSignature(),
             new PublicAccount(
                 transaction.getSignerPublicKey(),
-                extractNetworkType(transaction.getVersion())),
+                extractNetworkType(transaction.getVersion()), getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/MosaicSupplyChangeTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/MosaicSupplyChangeTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.okhttp.mappers;
 
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.mosaic.MosaicSupplyType;
 import io.nem.sdk.model.transaction.Deadline;
@@ -32,9 +33,10 @@ import io.nem.sdk.openapi.okhttp_gson.model.MosaicSupplyChangeTransactionDTO;
 class MosaicSupplyChangeTransactionMapper extends
     AbstractTransactionMapper<MosaicSupplyChangeTransactionDTO> {
 
-    public MosaicSupplyChangeTransactionMapper(JsonHelper jsonHelper) {
+    public MosaicSupplyChangeTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
         super(jsonHelper, TransactionType.MOSAIC_SUPPLY_CHANGE,
-            MosaicSupplyChangeTransactionDTO.class);
+            MosaicSupplyChangeTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -53,7 +55,7 @@ class MosaicSupplyChangeTransactionMapper extends
             transaction.getDelta(),
             transaction.getSignature(),
             new PublicAccount(transaction.getSignerPublicKey(),
-                extractNetworkType(transaction.getVersion())),
+                extractNetworkType(transaction.getVersion()), getSignSchema()),
             transactionInfo);
     }
 

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/MultisigAccountModificationTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/MultisigAccountModificationTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.okhttp.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.transaction.Deadline;
@@ -35,9 +36,10 @@ import java.util.stream.Collectors;
 class MultisigAccountModificationTransactionMapper extends
     AbstractTransactionMapper<MultisigAccountModificationTransactionDTO> {
 
-    public MultisigAccountModificationTransactionMapper(JsonHelper jsonHelper) {
+    public MultisigAccountModificationTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
         super(jsonHelper, TransactionType.MODIFY_MULTISIG_ACCOUNT,
-            MultisigAccountModificationTransactionDTO.class);
+            MultisigAccountModificationTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -56,7 +58,7 @@ class MultisigAccountModificationTransactionMapper extends
                                     multisigModification.getModificationAction().getValue()),
                                 PublicAccount.createFromPublicKey(
                                     multisigModification.getCosignatoryPublicKey(),
-                                    networkType)))
+                                    networkType, getSignSchema())))
                     .collect(Collectors.toList());
 
         return new MultisigAccountModificationTransaction(
@@ -68,7 +70,7 @@ class MultisigAccountModificationTransactionMapper extends
             transaction.getMinRemovalDelta().byteValue(),
             modifications,
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/NamespaceRegistrationTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/NamespaceRegistrationTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.okhttp.mappers;
 
 import static io.nem.core.utils.MapperUtils.toNamespaceId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.namespace.NamespaceType;
@@ -34,9 +35,10 @@ import java.util.Optional;
 class NamespaceRegistrationTransactionMapper extends
     AbstractTransactionMapper<NamespaceRegistrationTransactionDTO> {
 
-    public NamespaceRegistrationTransactionMapper(JsonHelper jsonHelper) {
+    public NamespaceRegistrationTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
         super(jsonHelper, TransactionType.REGISTER_NAMESPACE,
-            NamespaceRegistrationTransactionDTO.class);
+            NamespaceRegistrationTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -65,7 +67,7 @@ class NamespaceRegistrationTransactionMapper extends
             transaction.getSignature(),
             new PublicAccount(
                 transaction.getSignerPublicKey(),
-                extractNetworkType(transaction.getVersion())),
+                extractNetworkType(transaction.getVersion()), getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/SecretLockTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/SecretLockTransactionMapper.java
@@ -20,6 +20,7 @@ package io.nem.sdk.infrastructure.okhttp.mappers;
 import static io.nem.core.utils.MapperUtils.toAddressFromUnresolved;
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.mosaic.Mosaic;
@@ -34,8 +35,9 @@ import io.nem.sdk.openapi.okhttp_gson.model.SecretLockTransactionDTO;
 
 class SecretLockTransactionMapper extends AbstractTransactionMapper<SecretLockTransactionDTO> {
 
-    public SecretLockTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.SECRET_LOCK, SecretLockTransactionDTO.class);
+    public SecretLockTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
+        super(jsonHelper, TransactionType.SECRET_LOCK, SecretLockTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -59,7 +61,7 @@ class SecretLockTransactionMapper extends AbstractTransactionMapper<SecretLockTr
             transaction.getSecret(),
             toAddressFromUnresolved(transaction.getRecipientAddress()),
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/SecretProofTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/SecretProofTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.okhttp.mappers;
 
 import static io.nem.core.utils.MapperUtils.toAddressFromUnresolved;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.transaction.Deadline;
@@ -33,8 +34,9 @@ import io.nem.sdk.openapi.okhttp_gson.model.SecretProofTransactionDTO;
 class SecretProofTransactionMapper extends
     AbstractTransactionMapper<SecretProofTransactionDTO> {
 
-    public SecretProofTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.SECRET_PROOF, SecretProofTransactionDTO.class);
+    public SecretProofTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
+        super(jsonHelper, TransactionType.SECRET_PROOF, SecretProofTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -52,7 +54,7 @@ class SecretProofTransactionMapper extends
             transaction.getSecret(),
             transaction.getProof(),
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/TransferTransactionMapper.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/sdk/infrastructure/okhttp/mappers/TransferTransactionMapper.java
@@ -20,6 +20,7 @@ package io.nem.sdk.infrastructure.okhttp.mappers;
 import static io.nem.core.utils.MapperUtils.toAddressFromUnresolved;
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.mosaic.Mosaic;
 import io.nem.sdk.model.transaction.Deadline;
@@ -40,8 +41,9 @@ import org.bouncycastle.util.encoders.Hex;
 
 class TransferTransactionMapper extends AbstractTransactionMapper<TransferTransactionDTO> {
 
-    public TransferTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.TRANSFER, TransferTransactionDTO.class);
+    public TransferTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
+        super(jsonHelper, TransactionType.TRANSFER, TransferTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -81,7 +83,7 @@ class TransferTransactionMapper extends AbstractTransactionMapper<TransferTransa
             transaction.getSignature(),
             new PublicAccount(
                 transaction.getSignerPublicKey(),
-                extractNetworkType(transaction.getVersion())),
+                extractNetworkType(transaction.getVersion()), getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/AbstractOkHttpRespositoryTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/AbstractOkHttpRespositoryTest.java
@@ -17,6 +17,7 @@
 package io.nem.sdk.infrastructure.okhttp;
 
 import com.google.gson.Gson;
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.HttpStatus;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -45,6 +46,7 @@ import org.mockito.Mockito;
  */
 public abstract class AbstractOkHttpRespositoryTest {
 
+    protected SignSchema signSchema = SignSchema.DEFAULT;
 
     protected ApiClient apiClientMock;
 

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/AccountRepositoryOkHttpImplTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/AccountRepositoryOkHttpImplTest.java
@@ -46,7 +46,7 @@ public class AccountRepositoryOkHttpImplTest extends AbstractOkHttpRespositoryTe
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new AccountRepositoryOkHttpImpl(apiClientMock);
+        repository = new AccountRepositoryOkHttpImpl(apiClientMock, signSchema);
     }
 
     @Test

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/BlockRepositoryOkHttpImplTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/BlockRepositoryOkHttpImplTest.java
@@ -52,7 +52,7 @@ public class BlockRepositoryOkHttpImplTest extends AbstractOkHttpRespositoryTest
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new BlockRepositoryOkHttpImpl(apiClientMock);
+        repository = new BlockRepositoryOkHttpImpl(apiClientMock, signSchema);
     }
 
     @Test

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/ChainRepositoryOkHttpImplTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/ChainRepositoryOkHttpImplTest.java
@@ -37,7 +37,7 @@ public class ChainRepositoryOkHttpImplTest extends AbstractOkHttpRespositoryTest
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new ChainRepositoryOkHttpImpl(apiClientMock);
+        repository = new ChainRepositoryOkHttpImpl(apiClientMock, signSchema);
     }
 
     @Test

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/CollectionAdapterTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/CollectionAdapterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019. NEM
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.nem.sdk.infrastructure.okhttp;
+
+import com.google.gson.Gson;
+import io.nem.sdk.openapi.okhttp_gson.invoker.JSON;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CollectionAdapterTest {
+
+    @Test
+    public void shouldNotSerializeEmtpyLists() {
+        Gson gson = JSON.createGson().registerTypeHierarchyAdapter(
+            Collection.class, new CollectionAdapter()).create();
+
+        Assertions.assertEquals("{\"name\":\"Lib1\"}", gson.toJson(new Library("Lib1", null)));
+        Assertions.assertEquals("{\"name\":\"Lib2\"}", gson.toJson(new Library("Lib2", Collections.emptyList())));
+        Assertions
+            .assertEquals("{\"name\":\"Lib3\",\"books\":[\"book1\",\"book2\"]}", gson.toJson(new Library("Lib3", Arrays.asList("book1", "book2"))));
+    }
+
+    @Test
+    public void shouldSerializeEmtpyLists() {
+        Gson gson = JSON.createGson().create();
+
+        Assertions.assertEquals("{\"name\":\"Lib1\"}", gson.toJson(new Library("Lib1", null)));
+        Assertions.assertEquals("{\"name\":\"Lib2\",\"books\":[]}", gson.toJson(new Library("Lib2", Collections.emptyList())));
+        Assertions
+            .assertEquals("{\"name\":\"Lib3\",\"books\":[\"book1\",\"book2\"]}", gson.toJson(new Library("Lib3", Arrays.asList("book1", "book2"))));
+    }
+
+    public static class Library {
+
+        private final String name;
+        private final List<String> books;
+
+        public Library(String name, List<String> books) {
+            this.name = name;
+            this.books = books;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public List<String> getBooks() {
+            return books;
+        }
+    }
+}

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/DiagnosticRepositoryOkHttpImplTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/DiagnosticRepositoryOkHttpImplTest.java
@@ -38,7 +38,7 @@ public class DiagnosticRepositoryOkHttpImplTest extends AbstractOkHttpRespositor
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new DiagnosticRepositoryOkHttpImpl(apiClientMock);
+        repository = new DiagnosticRepositoryOkHttpImpl(apiClientMock, signSchema);
     }
 
     @Test

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/ListenerOkHttpTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/ListenerOkHttpTest.java
@@ -18,6 +18,7 @@ package io.nem.sdk.infrastructure.okhttp;
 import static org.mockito.Mockito.when;
 
 import com.google.gson.JsonObject;
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.infrastructure.ListenerChannel;
 import io.nem.sdk.infrastructure.ListenerSubscribeMessage;
 import io.nem.sdk.model.account.Address;
@@ -59,12 +60,13 @@ public class ListenerOkHttpTest {
     private JsonHelper jsonHelper;
 
     private String wsId = "TheWSid";
+    private SignSchema signSchema = SignSchema.DEFAULT;
 
     @BeforeEach
     public void setUp() {
         httpClientMock = Mockito.mock(OkHttpClient.class);
         String url = "http://nem.com:3000/";
-        listener = new ListenerOkHttp(httpClientMock, url, new JSON());
+        listener = new ListenerOkHttp(httpClientMock, url, new JSON(), signSchema);
         jsonHelper = listener.getJsonHelper();
     }
 
@@ -96,7 +98,7 @@ public class ListenerOkHttpTest {
 
         Address address = Address.createFromPublicKey(
             jsonHelper.getString(transactionInfoDtoJsonObject, "transaction", "signerPublicKey"),
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, signSchema);
 
         String channelName = ListenerChannel.CONFIRMED_ADDED.toString();
 

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/MosaicRepositoryOkHttpImplTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/MosaicRepositoryOkHttpImplTest.java
@@ -44,7 +44,7 @@ public class MosaicRepositoryOkHttpImplTest extends AbstractOkHttpRespositoryTes
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new MosaicRepositoryOkHttpImpl(apiClientMock);
+        repository = new MosaicRepositoryOkHttpImpl(apiClientMock, signSchema);
     }
 
 

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/NamespaceRepositoryOkHttpImplTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/NamespaceRepositoryOkHttpImplTest.java
@@ -50,7 +50,7 @@ public class NamespaceRepositoryOkHttpImplTest extends AbstractOkHttpRespository
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new NamespaceRepositoryOkHttpImpl(apiClientMock);
+        repository = new NamespaceRepositoryOkHttpImpl(apiClientMock, signSchema);
     }
 
 

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/NetworkRepositoryOkHttpImplTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/NetworkRepositoryOkHttpImplTest.java
@@ -34,7 +34,7 @@ public class NetworkRepositoryOkHttpImplTest extends AbstractOkHttpRespositoryTe
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new NetworkRepositoryOkHttpImpl(apiClientMock);
+        repository = new NetworkRepositoryOkHttpImpl(apiClientMock, signSchema);
     }
 
     @Test

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/NodeRepositoryOkHttpImplTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/NodeRepositoryOkHttpImplTest.java
@@ -41,7 +41,7 @@ public class NodeRepositoryOkHttpImplTest extends AbstractOkHttpRespositoryTest 
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new NodeRepositoryOkHttpImpl(apiClientMock);
+        repository = new NodeRepositoryOkHttpImpl(apiClientMock, signSchema);
     }
 
     @Test

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/OkHttpAggregateTransactionTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/OkHttpAggregateTransactionTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.infrastructure.okhttp.mappers.GeneralTransactionMapper;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.account.Address;
@@ -45,6 +46,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class OkHttpAggregateTransactionTest {
+
+    protected SignSchema signSchema = SignSchema.DEFAULT;
 
     private final String generationHash =
         "57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6";
@@ -72,7 +75,7 @@ public class OkHttpAggregateTransactionTest {
                     transferTx.toAggregate(
                         new PublicAccount(
                             "9A49366406ACA952B88BADF5F1E9BE6CE4968141035A60BE503273EA65456B24",
-                            NetworkType.MIJIN_TEST))),
+                            NetworkType.MIJIN_TEST, signSchema))),
                 NetworkType.MIJIN_TEST);
 
         assertEquals(NetworkType.MIJIN_TEST, aggregateTx.getNetworkType());
@@ -107,7 +110,7 @@ public class OkHttpAggregateTransactionTest {
                     transferTx.toAggregate(
                         new PublicAccount(
                             "846B4439154579A5903B1459C9CF69CB8153F6D0110A7A0ED61DE29AE4810BF2",
-                            NetworkType.MIJIN_TEST))),
+                            NetworkType.MIJIN_TEST, signSchema))),
                 NetworkType.MIJIN_TEST);
 
         byte[] actual = aggregateTx.generateBytes();
@@ -134,17 +137,17 @@ public class OkHttpAggregateTransactionTest {
                     transferTx.toAggregate(
                         new PublicAccount(
                             "B694186EE4AB0558CA4AFCFDD43B42114AE71094F5A1FC4A913FE9971CACD21D",
-                            NetworkType.MIJIN_TEST))),
+                            NetworkType.MIJIN_TEST, signSchema))),
                 NetworkType.MIJIN_TEST);
 
         Account cosignatoryAccount =
             new Account(
                 "2a2b1f5d366a5dd5dc56c3c757cf4fe6c66e2787087692cf329d7a49a594658b",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         Account cosignatoryAccount2 =
             new Account(
                 "b8afae6f4ad13a1b8aad047b488e0738a437c7389d4ff30c359ac068910c1d59",
-                NetworkType.MIJIN_TEST); // TODO bug with private key
+                NetworkType.MIJIN_TEST, signSchema); // TODO bug with private key
 
         SignedTransaction signedTransaction =
             cosignatoryAccount.signTransactionWithCosignatories(
@@ -163,24 +166,24 @@ public class OkHttpAggregateTransactionTest {
                 "shouldFindAccountInAsASignerOfTheTransaction.json");
 
         AggregateTransaction aggregateTransferTransaction =
-            (AggregateTransaction) new GeneralTransactionMapper(jsonHelper)
+            (AggregateTransaction) new GeneralTransactionMapper(jsonHelper, signSchema)
                 .map(aggregateTransferTransactionDTO);
 
         assertTrue(
             aggregateTransferTransaction.signedByAccount(
                 PublicAccount.createFromPublicKey(
                     "A5F82EC8EBB341427B6785C8111906CD0DF18838FB11B51CE0E18B5E79DFF630",
-                    NetworkType.MIJIN_TEST)));
+                    NetworkType.MIJIN_TEST, signSchema)));
         assertTrue(
             aggregateTransferTransaction.signedByAccount(
                 PublicAccount.createFromPublicKey(
                     "7681ED5023141D9CDCF184E5A7B60B7D466739918ED5DA30F7E71EA7B86EFF2D",
-                    NetworkType.MIJIN_TEST)));
+                    NetworkType.MIJIN_TEST, signSchema)));
         assertFalse(
             aggregateTransferTransaction.signedByAccount(
                 PublicAccount.createFromPublicKey(
                     "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                    NetworkType.MIJIN_TEST)));
+                    NetworkType.MIJIN_TEST, signSchema)));
     }
 
 

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/OkHttpCosignatureTransactionTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/OkHttpCosignatureTransactionTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.infrastructure.okhttp.mappers.GeneralTransactionMapper;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -38,6 +39,8 @@ import org.junit.jupiter.api.Test;
 
 public class OkHttpCosignatureTransactionTest {
 
+    static SignSchema signSchema = SignSchema.DEFAULT;
+
     static Account account;
 
 
@@ -48,7 +51,7 @@ public class OkHttpCosignatureTransactionTest {
         account =
             new Account(
                 "26b64cb10f005e5988a36744ca19e20d835ccc7c105aaa5f3b212da593180930",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
     }
 
     @Test
@@ -56,7 +59,7 @@ public class OkHttpCosignatureTransactionTest {
         TransactionInfoDTO transactionInfoDTO = TestHelperOkHttp.loadCosignatureTransactionInfoDTO(
             "createACosignatureTransactionViaConstructor.json");
         AggregateTransaction aggregateTransaction =
-            (AggregateTransaction) new GeneralTransactionMapper(jsonHelper)
+            (AggregateTransaction) new GeneralTransactionMapper(jsonHelper, signSchema)
                 .map(transactionInfoDTO);
 
         CosignatureTransaction cosignatureTransaction =

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/RepositoryFactoryOkHttpImplTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/RepositoryFactoryOkHttpImplTest.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.okhttp;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.RepositoryFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,7 @@ public class RepositoryFactoryOkHttpImplTest {
         String baseUrl = "https://nem.com:3000/path";
 
         RepositoryFactory factory = new RepositoryFactoryOkHttpImpl(
-            baseUrl);
+            baseUrl, SignSchema.DEFAULT);
 
         Assertions.assertNotNull(factory.createAccountRepository());
         Assertions.assertNotNull(factory.createBlockRepository());
@@ -45,5 +46,6 @@ public class RepositoryFactoryOkHttpImplTest {
         Assertions.assertNotNull(factory.createNodeRepository());
         Assertions.assertNotNull(factory.createTransactionRepository());
     }
+
 
 }

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/TransactionMapperOkHttpTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/TransactionMapperOkHttpTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.infrastructure.okhttp.mappers.GeneralTransactionMapper;
 import io.nem.sdk.model.account.Address;
@@ -28,12 +29,12 @@ import io.nem.sdk.model.namespace.AliasAction;
 import io.nem.sdk.model.namespace.NamespaceType;
 import io.nem.sdk.model.transaction.AddressAliasTransaction;
 import io.nem.sdk.model.transaction.AggregateTransaction;
-import io.nem.sdk.model.transaction.JsonHelper;
 import io.nem.sdk.model.transaction.HashLockTransaction;
-import io.nem.sdk.model.transaction.MultisigAccountModificationTransaction;
+import io.nem.sdk.model.transaction.JsonHelper;
 import io.nem.sdk.model.transaction.MosaicAliasTransaction;
 import io.nem.sdk.model.transaction.MosaicDefinitionTransaction;
 import io.nem.sdk.model.transaction.MosaicSupplyChangeTransaction;
+import io.nem.sdk.model.transaction.MultisigAccountModificationTransaction;
 import io.nem.sdk.model.transaction.NamespaceRegistrationTransaction;
 import io.nem.sdk.model.transaction.SecretLockTransaction;
 import io.nem.sdk.model.transaction.SecretProofTransaction;
@@ -61,6 +62,7 @@ import org.junit.jupiter.api.Test;
 
 public class TransactionMapperOkHttpTest {
 
+    private final SignSchema signSchema = SignSchema.DEFAULT;
 
     private final JsonHelper jsonHelper = new JsonHelperGson(new JSON().getGson());
 
@@ -285,7 +287,7 @@ public class TransactionMapperOkHttpTest {
     }
 
     private Transaction map(TransactionInfoDTO jsonObject) {
-        return new GeneralTransactionMapper(jsonHelper).map(jsonObject);
+        return new GeneralTransactionMapper(jsonHelper, signSchema).map(jsonObject);
     }
 
     void validateStandaloneTransaction(Transaction transaction, TransactionInfoDTO transactionDTO) {
@@ -361,7 +363,8 @@ public class TransactionMapperOkHttpTest {
         if (transaction.getType() == TransactionType.TRANSFER) {
             validateTransferTx((TransferTransaction) transaction, transactionDTO);
         } else if (transaction.getType() == TransactionType.REGISTER_NAMESPACE) {
-            validateNamespaceCreationTx((NamespaceRegistrationTransaction) transaction, transactionDTO);
+            validateNamespaceCreationTx((NamespaceRegistrationTransaction) transaction,
+                transactionDTO);
         } else if (transaction.getType() == TransactionType.MOSAIC_DEFINITION) {
             validateMosaicCreationTx((MosaicDefinitionTransaction) transaction, transactionDTO);
         } else if (transaction.getType() == TransactionType.MOSAIC_SUPPLY_CHANGE) {

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/TransactionRepositoryOkHttpImplTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/TransactionRepositoryOkHttpImplTest.java
@@ -20,6 +20,7 @@ import static io.nem.sdk.infrastructure.okhttp.TestHelperOkHttp.loadTransactionI
 import static java.time.temporal.ChronoUnit.HOURS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -50,11 +51,10 @@ public class TransactionRepositoryOkHttpImplTest extends AbstractOkHttpResposito
 
     private TransactionRepositoryOkHttpImpl repository;
 
-
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new TransactionRepositoryOkHttpImpl(apiClientMock);
+        repository = new TransactionRepositoryOkHttpImpl(apiClientMock, SignSchema.DEFAULT);
     }
 
     @Test
@@ -180,7 +180,8 @@ public class TransactionRepositoryOkHttpImplTest extends AbstractOkHttpResposito
         String generationHash = "A94B1BE81F1D4C95D6D252AD7BA3FFFB1674991FD880B7A57DC3180AF8D69C32";
 
         Account account = Account.createFromPrivateKey(
-            "063F36659A8BB01D5685826C19E2C2CA9D281465B642BD5E43CB69510408ECF7", networkType);
+            "063F36659A8BB01D5685826C19E2C2CA9D281465B642BD5E43CB69510408ECF7", networkType,
+            signSchema);
 
         Address address =
             Address.createFromRawAddress(

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/AbstractRepositoryVertxImpl.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/AbstractRepositoryVertxImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.vertx;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.QueryParams;
 import io.nem.sdk.api.RepositoryCallException;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -48,9 +49,13 @@ public abstract class AbstractRepositoryVertxImpl {
 
     private final JsonHelper jsonHelper;
 
-    public AbstractRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType) {
+    private final SignSchema signSchema;
+
+    public AbstractRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType,
+        SignSchema signSchema) {
         this.networkType = networkType;
         this.jsonHelper = new JsonHelperJackson2(apiClient.getObjectMapper());
+        this.signSchema = signSchema;
     }
 
     public <T> Observable<T> call(Consumer<Handler<AsyncResult<T>>> callback) {
@@ -109,5 +114,9 @@ public abstract class AbstractRepositoryVertxImpl {
 
     public JsonHelper getJsonHelper() {
         return jsonHelper;
+    }
+
+    public SignSchema getSignSchema() {
+        return signSchema;
     }
 }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/ChainRepositoryVertxImpl.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/ChainRepositoryVertxImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.vertx;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.ChainRepository;
 import io.nem.sdk.model.blockchain.BlockchainScore;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -39,8 +40,9 @@ public class ChainRepositoryVertxImpl extends AbstractRepositoryVertxImpl implem
 
     private final ChainRoutesApi client;
 
-    public ChainRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType) {
-        super(apiClient, networkType);
+    public ChainRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType,
+        SignSchema signSchema) {
+        super(apiClient, networkType, signSchema);
         client = new ChainRoutesApiImpl(apiClient);
     }
 

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/DiagnosticRepositoryVertxImpl.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/DiagnosticRepositoryVertxImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.vertx;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.DiagnosticRepository;
 import io.nem.sdk.model.blockchain.BlockchainStorageInfo;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -40,8 +41,9 @@ public class DiagnosticRepositoryVertxImpl extends AbstractRepositoryVertxImpl i
 
     private final DiagnosticRoutesApi client;
 
-    public DiagnosticRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType) {
-        super(apiClient, networkType);
+    public DiagnosticRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType,
+        SignSchema signSchema) {
+        super(apiClient, networkType, signSchema);
         client = new DiagnosticRoutesApiImpl(apiClient);
     }
 

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/ListenerVertx.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/ListenerVertx.java
@@ -17,6 +17,7 @@
 package io.nem.sdk.infrastructure.vertx;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.infrastructure.Listener;
 import io.nem.sdk.infrastructure.ListenerBase;
 import io.nem.sdk.infrastructure.ListenerChannel;
@@ -56,6 +57,7 @@ public class ListenerVertx extends ListenerBase implements Listener {
     private final HttpClient httpClient;
 
     private final TransactionMapper transactionMapper;
+    private final SignSchema signSchema;
 
     private WebSocket webSocket;
 
@@ -64,8 +66,10 @@ public class ListenerVertx extends ListenerBase implements Listener {
     /**
      * @param httpClient the http client instance.
      * @param url of the host
+     * @param signSchema the {@link SignSchema}
      */
-    public ListenerVertx(HttpClient httpClient, String url) {
+    public ListenerVertx(HttpClient httpClient, String url, SignSchema signSchema) {
+        this.signSchema = signSchema;
         try {
             this.url = new URL(url);
         } catch (MalformedURLException e) {
@@ -74,14 +78,14 @@ public class ListenerVertx extends ListenerBase implements Listener {
         }
         this.httpClient = httpClient;
         this.jsonHelper = new JsonHelperJackson2(JsonHelperJackson2.configureMapper(Json.mapper));
-        this.transactionMapper = new GeneralTransactionMapper(jsonHelper);
+        this.transactionMapper = new GeneralTransactionMapper(jsonHelper, this.signSchema);
     }
 
     /**
      * @param url of the host
      */
-    public ListenerVertx(String url) {
-        this(createHttpClient(), url);
+    public ListenerVertx(String url, SignSchema signSchema) {
+        this(createHttpClient(), url, signSchema);
     }
 
     private static HttpClient createHttpClient() {
@@ -153,7 +157,7 @@ public class ListenerVertx extends ListenerBase implements Listener {
     }
 
     private BlockInfo toBlockInfo(BlockInfoDTO blockInfoDTO) {
-        return BlockRepositoryVertxImpl.toBlockInfo(blockInfoDTO);
+        return BlockRepositoryVertxImpl.toBlockInfo(signSchema, blockInfoDTO);
     }
 
     private Transaction toTransaction(TransactionInfoDTO transactionInfo) {

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/MosaicRepositoryVertxImpl.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/MosaicRepositoryVertxImpl.java
@@ -18,6 +18,7 @@ package io.nem.sdk.infrastructure.vertx;
 
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.MosaicRepository;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -52,8 +53,9 @@ public class MosaicRepositoryVertxImpl extends AbstractRepositoryVertxImpl imple
 
     private final MosaicRoutesApi client;
 
-    public MosaicRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType) {
-        super(apiClient, networkType);
+    public MosaicRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType,
+        SignSchema signSchema) {
+        super(apiClient, networkType, signSchema);
         client = new MosaicRoutesApiImpl(apiClient);
     }
 
@@ -89,7 +91,8 @@ public class MosaicRepositoryVertxImpl extends AbstractRepositoryVertxImpl imple
             toMosaicId(mosaicInfoDTO.getMosaic().getId()),
             mosaicInfoDTO.getMosaic().getSupply(),
             mosaicInfoDTO.getMosaic().getStartHeight(),
-            new PublicAccount(mosaicInfoDTO.getMosaic().getOwnerPublicKey(), networkType),
+            new PublicAccount(mosaicInfoDTO.getMosaic().getOwnerPublicKey(), networkType,
+                getSignSchema()),
             mosaicInfoDTO.getMosaic().getRevision(),
             extractMosaicProperties(mosaicInfoDTO.getMosaic().getProperties()));
     }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/NamespaceRepositoryVertxImpl.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/NamespaceRepositoryVertxImpl.java
@@ -18,6 +18,7 @@ package io.nem.sdk.infrastructure.vertx;
 
 import static io.nem.core.utils.MapperUtils.toNamespaceId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.api.NamespaceRepository;
 import io.nem.sdk.api.QueryParams;
@@ -63,8 +64,9 @@ public class NamespaceRepositoryVertxImpl extends AbstractRepositoryVertxImpl im
 
     private final NamespaceRoutesApi client;
 
-    public NamespaceRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType) {
-        super(apiClient, networkType);
+    public NamespaceRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType,
+        SignSchema signSchema) {
+        super(apiClient, networkType, signSchema);
         client = new NamespaceRoutesApiImpl(apiClient);
     }
 
@@ -204,7 +206,7 @@ public class NamespaceRepositoryVertxImpl extends AbstractRepositoryVertxImpl im
             this.extractLevels(namespaceInfoDTO),
             toNamespaceId(namespaceInfoDTO.getNamespace().getParentId()),
             new PublicAccount(namespaceInfoDTO.getNamespace().getOwnerPublicKey(),
-                getNetworkTypeBlocking()),
+                getNetworkTypeBlocking(), getSignSchema()),
             namespaceInfoDTO.getNamespace().getStartHeight(),
             namespaceInfoDTO.getNamespace().getEndHeight(),
             this.extractAlias(namespaceInfoDTO.getNamespace()));

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/NetworkRepositoryVertxImpl.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/NetworkRepositoryVertxImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.vertx;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.NetworkRepository;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.openapi.vertx.api.NetworkRoutesApi;
@@ -37,8 +38,8 @@ public class NetworkRepositoryVertxImpl extends AbstractRepositoryVertxImpl impl
 
     private final NetworkRoutesApi client;
 
-    public NetworkRepositoryVertxImpl(ApiClient apiClient) {
-        super(apiClient, null);
+    public NetworkRepositoryVertxImpl(ApiClient apiClient, SignSchema signSchema) {
+        super(apiClient, null, signSchema);
         client = new NetworkRoutesApiImpl(apiClient);
     }
 

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/NodeRepositoryVertxImpl.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/NodeRepositoryVertxImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.vertx;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.NodeRepository;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.node.NodeInfo;
@@ -41,8 +42,9 @@ public class NodeRepositoryVertxImpl extends AbstractRepositoryVertxImpl impleme
 
     private final NodeRoutesApi client;
 
-    public NodeRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType) {
-        super(apiClient, networkType);
+    public NodeRepositoryVertxImpl(ApiClient apiClient, Supplier<NetworkType> networkType,
+        SignSchema signSchema) {
+        super(apiClient, networkType, signSchema);
         client = new NodeRoutesApiImpl(apiClient);
     }
 

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/ReceiptMappingVertx.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/ReceiptMappingVertx.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.vertx;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.account.PublicAccount;
@@ -52,8 +53,10 @@ import java.util.stream.Collectors;
 public class ReceiptMappingVertx {
 
     private final JsonHelper jsonHelper;
+    private final SignSchema signSchema;
 
-    public ReceiptMappingVertx(JsonHelper jsonHelper) {
+    public ReceiptMappingVertx(SignSchema signSchema, JsonHelper jsonHelper) {
+        this.signSchema = signSchema;
         this.jsonHelper = jsonHelper;
     }
 
@@ -162,7 +165,8 @@ public class ReceiptMappingVertx {
     public BalanceChangeReceipt createBalanceChangeReceipt(
         BalanceChangeReceiptDTO receipt, NetworkType networkType) {
         return new BalanceChangeReceipt(
-            PublicAccount.createFromPublicKey(receipt.getTargetPublicKey(), networkType),
+            PublicAccount
+                .createFromPublicKey(receipt.getTargetPublicKey(), networkType, signSchema),
             new MosaicId(receipt.getMosaicId()),
             receipt.getAmount(),
             ReceiptType.rawValueOf(receipt.getType().getValue()),
@@ -172,7 +176,8 @@ public class ReceiptMappingVertx {
     public BalanceTransferReceipt<Address> createBalanceTransferRecipient(
         BalanceTransferReceiptDTO receipt, NetworkType networkType) {
         return new BalanceTransferReceipt<>(
-            PublicAccount.createFromPublicKey(receipt.getSenderPublicKey(), networkType),
+            PublicAccount
+                .createFromPublicKey(receipt.getSenderPublicKey(), networkType, signSchema),
             MapperUtils.toAddressFromUnresolved(receipt.getRecipientAddress()),
             new MosaicId(receipt.getMosaicId()),
             receipt.getAmount(),

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/TransactionRepositoryVertxImpl.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/TransactionRepositoryVertxImpl.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.vertx;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.TransactionRepository;
 import io.nem.sdk.infrastructure.vertx.mappers.GeneralTransactionMapper;
 import io.nem.sdk.infrastructure.vertx.mappers.TransactionMapper;
@@ -56,10 +57,10 @@ public class TransactionRepositoryVertxImpl extends AbstractRepositoryVertxImpl 
     private final TransactionMapper transactionMapper;
 
     public TransactionRepositoryVertxImpl(ApiClient apiClient,
-        Supplier<NetworkType> networkType) {
-        super(apiClient, networkType);
+        Supplier<NetworkType> networkType, SignSchema signSchema) {
+        super(apiClient, networkType, signSchema);
         client = new TransactionRoutesApiImpl(apiClient);
-        transactionMapper = new GeneralTransactionMapper(getJsonHelper());
+        transactionMapper = new GeneralTransactionMapper(getJsonHelper(), signSchema);
     }
 
 

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/AbstractTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/AbstractTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.vertx.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.transaction.JsonHelper;
 import io.nem.sdk.model.transaction.Transaction;
@@ -41,10 +42,13 @@ public abstract class AbstractTransactionMapper<T> implements TransactionMapper 
 
     private final JsonHelper jsonHelper;
 
-    private Class<T> transactionDtoClass;
+    private final Class<T> transactionDtoClass;
+
+    private final SignSchema signSchema;
 
     public AbstractTransactionMapper(JsonHelper jsonHelper, TransactionType transactionType,
-        Class<T> transactionDtoClass) {
+        Class<T> transactionDtoClass, SignSchema signSchema) {
+        this.signSchema = signSchema;
         this.jsonHelper = jsonHelper;
         this.transactionType = transactionType;
         this.transactionDtoClass = transactionDtoClass;
@@ -127,5 +131,9 @@ public abstract class AbstractTransactionMapper<T> implements TransactionMapper 
     @Override
     public TransactionType getTransactionType() {
         return transactionType;
+    }
+
+    protected SignSchema getSignSchema() {
+        return signSchema;
     }
 }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/AccountLinkTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/AccountLinkTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.vertx.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.transaction.AccountLinkAction;
@@ -31,8 +32,9 @@ import io.nem.sdk.openapi.vertx.model.AccountLinkTransactionDTO;
 class AccountLinkTransactionMapper extends AbstractTransactionMapper<AccountLinkTransactionDTO> {
 
 
-    public AccountLinkTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.ACCOUNT_LINK, AccountLinkTransactionDTO.class);
+    public AccountLinkTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
+        super(jsonHelper, TransactionType.ACCOUNT_LINK, AccountLinkTransactionDTO.class,
+            signSchema);
     }
 
     @Override
@@ -46,10 +48,11 @@ class AccountLinkTransactionMapper extends AbstractTransactionMapper<AccountLink
             deadline,
             transaction.getMaxFee(),
             PublicAccount
-                .createFromPublicKey(transaction.getRemotePublicKey(), networkType),
+                .createFromPublicKey(transaction.getRemotePublicKey(), networkType,
+                    getSignSchema()),
             AccountLinkAction.rawValueOf(transaction.getLinkAction().getValue()),
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/AddressAliasTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/AddressAliasTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.vertx.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -35,8 +36,10 @@ class AddressAliasTransactionMapper extends
     AbstractTransactionMapper<AddressAliasTransactionDTO> {
 
 
-    public AddressAliasTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.ADDRESS_ALIAS, AddressAliasTransactionDTO.class);
+    public AddressAliasTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
+        super(jsonHelper, TransactionType.ADDRESS_ALIAS, AddressAliasTransactionDTO.class,
+            signSchema
+        );
     }
 
     @Override
@@ -56,7 +59,8 @@ class AddressAliasTransactionMapper extends
             namespaceId,
             MapperUtils.toAddressFromUnresolved(transaction.getAddress()),
             Optional.ofNullable(transaction.getSignature()),
-            Optional.of(new PublicAccount(transaction.getSignerPublicKey(), networkType)),
+            Optional.of(new PublicAccount(transaction.getSignerPublicKey(), networkType,
+                getSignSchema())),
             Optional.of(transactionInfo));
     }
 }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/AggregateTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/AggregateTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.vertx.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.transaction.AggregateTransaction;
@@ -38,10 +39,9 @@ class AggregateTransactionMapper extends
 
     private TransactionMapper transactionMapper;
 
-    public AggregateTransactionMapper(JsonHelper jsonHelper,
-        TransactionType transactionType,
-        TransactionMapper transactionMapper) {
-        super(jsonHelper, transactionType, AggregateBondedTransactionDTO.class);
+    public AggregateTransactionMapper(JsonHelper jsonHelper, TransactionType transactionType,
+        TransactionMapper transactionMapper, SignSchema signSchema) {
+        super(jsonHelper, transactionType, AggregateBondedTransactionDTO.class, signSchema);
         this.transactionMapper = transactionMapper;
     }
 
@@ -77,7 +77,7 @@ class AggregateTransactionMapper extends
                             new AggregateTransactionCosignature(
                                 aggregateCosignature.getSignature(),
                                 new PublicAccount(aggregateCosignature.getSignerPublicKey(),
-                                    networkType)))
+                                    networkType, getSignSchema())))
                     .collect(Collectors.toList());
         }
 
@@ -90,7 +90,7 @@ class AggregateTransactionMapper extends
             transactions,
             cosignatures,
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/GeneralTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/GeneralTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.vertx.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.transaction.JsonHelper;
 import io.nem.sdk.model.transaction.Transaction;
 import io.nem.sdk.model.transaction.TransactionType;
@@ -34,26 +35,29 @@ public class GeneralTransactionMapper implements TransactionMapper {
 
     private final JsonHelper jsonHelper;
 
-    private Map<TransactionType, TransactionMapper> transactionMappers = new EnumMap<>(TransactionType.class);
+    private Map<TransactionType, TransactionMapper> transactionMappers = new EnumMap<>(
+        TransactionType.class);
 
-    public GeneralTransactionMapper(JsonHelper jsonHelper) {
+    public GeneralTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
         this.jsonHelper = jsonHelper;
-        register(new AccountLinkTransactionMapper(jsonHelper));
-        register(new AddressAliasTransactionMapper(jsonHelper));
-        register(new HashLockTransactionMapper(jsonHelper));
-        register(new MosaicAliasTransactionMapper(jsonHelper));
-        register(new MosaicDefinitionTransactionMapper(jsonHelper));
-        register(new MosaicSupplyChangeTransactionMapper(jsonHelper));
-        register(new MultisigAccountModificationTransactionMapper(jsonHelper));
-        register(new NamespaceRegistrationTransactionMapper(jsonHelper));
-        register(new SecretLockTransactionMapper(jsonHelper));
-        register(new SecretProofTransactionMapper(jsonHelper));
-        register(new TransferTransactionMapper(jsonHelper));
+        register(new AccountLinkTransactionMapper(jsonHelper, signSchema));
+        register(new AddressAliasTransactionMapper(jsonHelper, signSchema));
+        register(new HashLockTransactionMapper(jsonHelper, signSchema));
+        register(new MosaicAliasTransactionMapper(jsonHelper, signSchema));
+        register(new MosaicDefinitionTransactionMapper(jsonHelper, signSchema));
+        register(new MosaicSupplyChangeTransactionMapper(jsonHelper, signSchema));
+        register(new MultisigAccountModificationTransactionMapper(jsonHelper, signSchema));
+        register(new NamespaceRegistrationTransactionMapper(jsonHelper, signSchema));
+        register(new SecretLockTransactionMapper(jsonHelper, signSchema));
+        register(new SecretProofTransactionMapper(jsonHelper, signSchema));
+        register(new TransferTransactionMapper(jsonHelper, signSchema));
 
         register(
-            new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_BONDED, this));
+            new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_BONDED, this,
+                signSchema));
         register(
-            new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_COMPLETE, this));
+            new AggregateTransactionMapper(jsonHelper, TransactionType.AGGREGATE_COMPLETE, this,
+                signSchema));
     }
 
     private void register(TransactionMapper mapper) {

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/HashLockTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/HashLockTransactionMapper.java
@@ -19,12 +19,13 @@ package io.nem.sdk.infrastructure.vertx.mappers;
 
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.mosaic.Mosaic;
 import io.nem.sdk.model.transaction.Deadline;
-import io.nem.sdk.model.transaction.JsonHelper;
 import io.nem.sdk.model.transaction.HashLockTransaction;
+import io.nem.sdk.model.transaction.JsonHelper;
 import io.nem.sdk.model.transaction.SignedTransaction;
 import io.nem.sdk.model.transaction.Transaction;
 import io.nem.sdk.model.transaction.TransactionInfo;
@@ -33,8 +34,8 @@ import io.nem.sdk.openapi.vertx.model.HashLockTransactionDTO;
 
 class HashLockTransactionMapper extends AbstractTransactionMapper<HashLockTransactionDTO> {
 
-    public HashLockTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.LOCK, HashLockTransactionDTO.class);
+    public HashLockTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
+        super(jsonHelper, TransactionType.LOCK, HashLockTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -54,7 +55,7 @@ class HashLockTransactionMapper extends AbstractTransactionMapper<HashLockTransa
             new SignedTransaction("", transaction.getHash(),
                 TransactionType.AGGREGATE_BONDED),
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/MosaicAliasTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/MosaicAliasTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.vertx.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -34,8 +35,9 @@ import java.util.Optional;
 class MosaicAliasTransactionMapper extends
     AbstractTransactionMapper<MosaicAliasTransactionDTO> {
 
-    public MosaicAliasTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.MOSAIC_ALIAS, MosaicAliasTransactionDTO.class);
+    public MosaicAliasTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
+        super(jsonHelper, TransactionType.MOSAIC_ALIAS, MosaicAliasTransactionDTO.class,
+            signSchema);
     }
 
     @Override
@@ -55,7 +57,8 @@ class MosaicAliasTransactionMapper extends
             namespaceId,
             MapperUtils.toMosaicId(transaction.getMosaicId()),
             Optional.ofNullable(transaction.getSignature()),
-            Optional.of(new PublicAccount(transaction.getSignerPublicKey(), networkType)),
+            Optional.of(new PublicAccount(transaction.getSignerPublicKey(), networkType,
+                getSignSchema())),
             Optional.of(transactionInfo));
     }
 }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/MosaicDefinitionTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/MosaicDefinitionTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.vertx.mappers;
 
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.mosaic.MosaicNonce;
 import io.nem.sdk.model.mosaic.MosaicProperties;
@@ -33,8 +34,10 @@ import io.nem.sdk.openapi.vertx.model.MosaicDefinitionTransactionDTO;
 class MosaicDefinitionTransactionMapper extends
     AbstractTransactionMapper<MosaicDefinitionTransactionDTO> {
 
-    public MosaicDefinitionTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.MOSAIC_DEFINITION, MosaicDefinitionTransactionDTO.class);
+    public MosaicDefinitionTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
+        super(jsonHelper, TransactionType.MOSAIC_DEFINITION, MosaicDefinitionTransactionDTO.class,
+            signSchema
+        );
     }
 
     @Override
@@ -64,7 +67,7 @@ class MosaicDefinitionTransactionMapper extends
             transaction.getSignature(),
             new PublicAccount(
                 transaction.getSignerPublicKey(),
-                extractNetworkType(transaction.getVersion())),
+                extractNetworkType(transaction.getVersion()), getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/MosaicSupplyChangeTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/MosaicSupplyChangeTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.vertx.mappers;
 
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.mosaic.MosaicSupplyType;
 import io.nem.sdk.model.transaction.Deadline;
@@ -32,9 +33,10 @@ import io.nem.sdk.openapi.vertx.model.MosaicSupplyChangeTransactionDTO;
 class MosaicSupplyChangeTransactionMapper extends
     AbstractTransactionMapper<MosaicSupplyChangeTransactionDTO> {
 
-    public MosaicSupplyChangeTransactionMapper(JsonHelper jsonHelper) {
+    public MosaicSupplyChangeTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
         super(jsonHelper, TransactionType.MOSAIC_SUPPLY_CHANGE,
-            MosaicSupplyChangeTransactionDTO.class);
+            MosaicSupplyChangeTransactionDTO.class, signSchema
+        );
     }
 
     @Override
@@ -53,7 +55,7 @@ class MosaicSupplyChangeTransactionMapper extends
             transaction.getDelta(),
             transaction.getSignature(),
             new PublicAccount(transaction.getSignerPublicKey(),
-                extractNetworkType(transaction.getVersion())),
+                extractNetworkType(transaction.getVersion()), getSignSchema()),
             transactionInfo);
     }
 

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/MultisigAccountModificationTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/MultisigAccountModificationTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.vertx.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.transaction.Deadline;
@@ -35,9 +36,11 @@ import java.util.stream.Collectors;
 class MultisigAccountModificationTransactionMapper extends
     AbstractTransactionMapper<MultisigAccountModificationTransactionDTO> {
 
-    public MultisigAccountModificationTransactionMapper(JsonHelper jsonHelper) {
+    public MultisigAccountModificationTransactionMapper(JsonHelper jsonHelper,
+        SignSchema signSchema) {
         super(jsonHelper, TransactionType.MODIFY_MULTISIG_ACCOUNT,
-            MultisigAccountModificationTransactionDTO.class);
+            MultisigAccountModificationTransactionDTO.class, signSchema
+        );
     }
 
     @Override
@@ -56,7 +59,7 @@ class MultisigAccountModificationTransactionMapper extends
                                     multisigModification.getModificationAction().getValue()),
                                 PublicAccount.createFromPublicKey(
                                     multisigModification.getCosignatoryPublicKey(),
-                                    networkType)))
+                                    networkType, getSignSchema())))
                     .collect(Collectors.toList());
 
         return new MultisigAccountModificationTransaction(
@@ -68,7 +71,7 @@ class MultisigAccountModificationTransactionMapper extends
             transaction.getMinRemovalDelta().byteValue(),
             modifications,
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/NamespaceRegistrationTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/NamespaceRegistrationTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.vertx.mappers;
 
 import static io.nem.core.utils.MapperUtils.toNamespaceId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.namespace.NamespaceType;
@@ -34,9 +35,10 @@ import java.util.Optional;
 class NamespaceRegistrationTransactionMapper extends
     AbstractTransactionMapper<NamespaceRegistrationTransactionDTO> {
 
-    public NamespaceRegistrationTransactionMapper(JsonHelper jsonHelper) {
+    public NamespaceRegistrationTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
         super(jsonHelper, TransactionType.REGISTER_NAMESPACE,
-            NamespaceRegistrationTransactionDTO.class);
+            NamespaceRegistrationTransactionDTO.class, signSchema
+        );
     }
 
     @Override
@@ -65,7 +67,7 @@ class NamespaceRegistrationTransactionMapper extends
             transaction.getSignature(),
             new PublicAccount(
                 transaction.getSignerPublicKey(),
-                extractNetworkType(transaction.getVersion())),
+                extractNetworkType(transaction.getVersion()), getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/SecretLockTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/SecretLockTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.vertx.mappers;
 
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -34,8 +35,8 @@ import io.nem.sdk.openapi.vertx.model.SecretLockTransactionDTO;
 
 class SecretLockTransactionMapper extends AbstractTransactionMapper<SecretLockTransactionDTO> {
 
-    public SecretLockTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.SECRET_LOCK, SecretLockTransactionDTO.class);
+    public SecretLockTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
+        super(jsonHelper, TransactionType.SECRET_LOCK, SecretLockTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -59,7 +60,7 @@ class SecretLockTransactionMapper extends AbstractTransactionMapper<SecretLockTr
             transaction.getSecret(),
             MapperUtils.toAddressFromUnresolved(transaction.getRecipientAddress()),
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/SecretProofTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/SecretProofTransactionMapper.java
@@ -17,6 +17,7 @@
 
 package io.nem.sdk.infrastructure.vertx.mappers;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -32,8 +33,9 @@ import io.nem.sdk.openapi.vertx.model.SecretProofTransactionDTO;
 class SecretProofTransactionMapper extends
     AbstractTransactionMapper<SecretProofTransactionDTO> {
 
-    public SecretProofTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.SECRET_PROOF, SecretProofTransactionDTO.class);
+    public SecretProofTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
+        super(jsonHelper, TransactionType.SECRET_PROOF, SecretProofTransactionDTO.class,
+            signSchema);
     }
 
     @Override
@@ -51,7 +53,7 @@ class SecretProofTransactionMapper extends
             transaction.getSecret(),
             transaction.getProof(),
             transaction.getSignature(),
-            new PublicAccount(transaction.getSignerPublicKey(), networkType),
+            new PublicAccount(transaction.getSignerPublicKey(), networkType, getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/TransferTransactionMapper.java
+++ b/sdk-vertx-client/src/main/java/io/nem/sdk/infrastructure/vertx/mappers/TransferTransactionMapper.java
@@ -19,6 +19,7 @@ package io.nem.sdk.infrastructure.vertx.mappers;
 
 import static io.nem.core.utils.MapperUtils.toMosaicId;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.mosaic.Mosaic;
@@ -40,8 +41,8 @@ import org.bouncycastle.util.encoders.Hex;
 
 class TransferTransactionMapper extends AbstractTransactionMapper<TransferTransactionDTO> {
 
-    public TransferTransactionMapper(JsonHelper jsonHelper) {
-        super(jsonHelper, TransactionType.TRANSFER, TransferTransactionDTO.class);
+    public TransferTransactionMapper(JsonHelper jsonHelper, SignSchema signSchema) {
+        super(jsonHelper, TransactionType.TRANSFER, TransferTransactionDTO.class, signSchema);
     }
 
     @Override
@@ -81,7 +82,7 @@ class TransferTransactionMapper extends AbstractTransactionMapper<TransferTransa
             transaction.getSignature(),
             new PublicAccount(
                 transaction.getSignerPublicKey(),
-                extractNetworkType(transaction.getVersion())),
+                extractNetworkType(transaction.getVersion()), getSignSchema()),
             transactionInfo);
     }
 }

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/AbstractVertxRespositoryTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/AbstractVertxRespositoryTest.java
@@ -17,6 +17,7 @@
 package io.nem.sdk.infrastructure.vertx;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.HttpStatus;
 import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -44,6 +45,7 @@ import org.mockito.stubbing.Answer;
  */
 public abstract class AbstractVertxRespositoryTest {
 
+    protected SignSchema signSchema = SignSchema.DEFAULT;
 
     protected ApiClient apiClientMock;
 

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/AccountRepositoryVertxImplTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/AccountRepositoryVertxImplTest.java
@@ -17,6 +17,7 @@
 package io.nem.sdk.infrastructure.vertx;
 
 import io.nem.core.crypto.PublicKey;
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.ExceptionUtils;
 import io.nem.sdk.api.RepositoryCallException;
 import io.nem.sdk.model.account.AccountInfo;
@@ -47,7 +48,7 @@ public class AccountRepositoryVertxImplTest extends AbstractVertxRespositoryTest
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new AccountRepositoryVertxImpl(apiClientMock, networkType);
+        repository = new AccountRepositoryVertxImpl(apiClientMock, networkType, signSchema);
     }
 
     @Test

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/BlockRepositoryVertxImplTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/BlockRepositoryVertxImplTest.java
@@ -52,7 +52,7 @@ public class BlockRepositoryVertxImplTest extends AbstractVertxRespositoryTest {
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new BlockRepositoryVertxImpl(apiClientMock, networkType);
+        repository = new BlockRepositoryVertxImpl(apiClientMock, networkType, signSchema);
     }
 
     @Test

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/ChainRepositoryVertxImplTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/ChainRepositoryVertxImplTest.java
@@ -37,7 +37,7 @@ public class ChainRepositoryVertxImplTest extends AbstractVertxRespositoryTest {
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new ChainRepositoryVertxImpl(apiClientMock, networkType);
+        repository = new ChainRepositoryVertxImpl(apiClientMock, networkType, signSchema);
     }
 
     @Test

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/DiagnosticRepositoryVertxImplTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/DiagnosticRepositoryVertxImplTest.java
@@ -38,7 +38,7 @@ public class DiagnosticRepositoryVertxImplTest extends AbstractVertxRespositoryT
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new DiagnosticRepositoryVertxImpl(apiClientMock, networkType);
+        repository = new DiagnosticRepositoryVertxImpl(apiClientMock, networkType, signSchema);
     }
 
     @Test

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/ListenerVertxTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/ListenerVertxTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.infrastructure.ListenerChannel;
 import io.nem.sdk.infrastructure.ListenerSubscribeMessage;
 import io.nem.sdk.model.account.Address;
@@ -65,7 +66,7 @@ public class ListenerVertxTest {
     public void setUp() {
         httpClientMock = Mockito.mock(HttpClient.class);
         String url = "http://nem.com:3000/";
-        listener = new ListenerVertx(httpClientMock, url);
+        listener = new ListenerVertx(httpClientMock, url, SignSchema.DEFAULT);
         jsonHelper = listener.getJsonHelper();
     }
 
@@ -97,7 +98,7 @@ public class ListenerVertxTest {
 
         Address address = Address.createFromPublicKey(
             jsonHelper.getString(transactionInfoDtoJsonObject, "transaction", "signerPublicKey"),
-            NetworkType.MIJIN_TEST);
+            NetworkType.MIJIN_TEST, SignSchema.DEFAULT);
 
         String channelName = ListenerChannel.CONFIRMED_ADDED.toString();
 

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/MosaicRepositoryVertxImplTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/MosaicRepositoryVertxImplTest.java
@@ -44,7 +44,7 @@ public class MosaicRepositoryVertxImplTest extends AbstractVertxRespositoryTest 
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new MosaicRepositoryVertxImpl(apiClientMock, networkType);
+        repository = new MosaicRepositoryVertxImpl(apiClientMock, networkType, signSchema);
     }
 
 

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/NamespaceRepositoryVertxImplTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/NamespaceRepositoryVertxImplTest.java
@@ -53,7 +53,7 @@ public class NamespaceRepositoryVertxImplTest extends AbstractVertxRespositoryTe
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new NamespaceRepositoryVertxImpl(apiClientMock, networkType);
+        repository = new NamespaceRepositoryVertxImpl(apiClientMock, networkType, signSchema);
     }
 
     @Test

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/NetworkRepositoryVertxImplTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/NetworkRepositoryVertxImplTest.java
@@ -34,7 +34,7 @@ public class NetworkRepositoryVertxImplTest extends AbstractVertxRespositoryTest
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new NetworkRepositoryVertxImpl(apiClientMock);
+        repository = new NetworkRepositoryVertxImpl(apiClientMock, signSchema);
     }
 
     @Test

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/NodeRepositoryOkVertxImplTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/NodeRepositoryOkVertxImplTest.java
@@ -41,7 +41,7 @@ public class NodeRepositoryOkVertxImplTest extends AbstractVertxRespositoryTest 
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new NodeRepositoryVertxImpl(apiClientMock, networkType);
+        repository = new NodeRepositoryVertxImpl(apiClientMock, networkType, signSchema);
     }
 
     @Test

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/RepositoryFactoryVertxImplTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/RepositoryFactoryVertxImplTest.java
@@ -16,6 +16,7 @@
 
 package io.nem.sdk.infrastructure.vertx;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.api.RepositoryCallException;
 import io.nem.sdk.api.RepositoryFactory;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -32,8 +33,7 @@ public class RepositoryFactoryVertxImplTest {
 
         String baseUrl = "https://nem.com:3000/path";
 
-        RepositoryFactory factory = new RepositoryFactoryVertxImpl(
-            baseUrl) {
+        RepositoryFactory factory = new RepositoryFactoryVertxImpl(baseUrl, SignSchema.DEFAULT) {
             @Override
             protected NetworkType loadNetworkType() {
                 return NetworkType.MAIN_NET;
@@ -58,7 +58,7 @@ public class RepositoryFactoryVertxImplTest {
         String baseUrl = "https://localhost:1934/path";
 
         RepositoryCallException e = Assertions.assertThrows(RepositoryCallException.class, () -> {
-            new RepositoryFactoryVertxImpl(baseUrl);
+            new RepositoryFactoryVertxImpl(baseUrl, SignSchema.DEFAULT);
         });
 
         Assertions.assertTrue(

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/TransactionMapperVertxTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/TransactionMapperVertxTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.core.utils.MapperUtils;
 import io.nem.sdk.infrastructure.vertx.mappers.GeneralTransactionMapper;
 import io.nem.sdk.model.account.Address;
@@ -28,12 +29,12 @@ import io.nem.sdk.model.namespace.AliasAction;
 import io.nem.sdk.model.namespace.NamespaceType;
 import io.nem.sdk.model.transaction.AddressAliasTransaction;
 import io.nem.sdk.model.transaction.AggregateTransaction;
-import io.nem.sdk.model.transaction.JsonHelper;
 import io.nem.sdk.model.transaction.HashLockTransaction;
-import io.nem.sdk.model.transaction.MultisigAccountModificationTransaction;
+import io.nem.sdk.model.transaction.JsonHelper;
 import io.nem.sdk.model.transaction.MosaicAliasTransaction;
 import io.nem.sdk.model.transaction.MosaicDefinitionTransaction;
 import io.nem.sdk.model.transaction.MosaicSupplyChangeTransaction;
+import io.nem.sdk.model.transaction.MultisigAccountModificationTransaction;
 import io.nem.sdk.model.transaction.NamespaceRegistrationTransaction;
 import io.nem.sdk.model.transaction.SecretLockTransaction;
 import io.nem.sdk.model.transaction.SecretProofTransaction;
@@ -71,7 +72,8 @@ public class TransactionMapperVertxTest {
     void shouldFailWhenNotTransactionType() {
         TransactionInfoDTO transaction = new TransactionInfoDTO();
 
-        Assertions.assertEquals("Transaction cannot be mapped, object does not not have transaction type.",
+        Assertions.assertEquals(
+            "Transaction cannot be mapped, object does not not have transaction type.",
             Assertions.assertThrows(IllegalArgumentException.class, () -> map(transaction))
                 .getMessage());
     }
@@ -297,7 +299,7 @@ public class TransactionMapperVertxTest {
     }
 
     private Transaction map(TransactionInfoDTO jsonObject) {
-        return new GeneralTransactionMapper(jsonHelper).map(jsonObject);
+        return new GeneralTransactionMapper(jsonHelper, SignSchema.DEFAULT).map(jsonObject);
     }
 
     void validateStandaloneTransaction(Transaction transaction, TransactionInfoDTO transactionDTO) {
@@ -373,7 +375,8 @@ public class TransactionMapperVertxTest {
         if (transaction.getType() == TransactionType.TRANSFER) {
             validateTransferTx((TransferTransaction) transaction, transactionDTO);
         } else if (transaction.getType() == TransactionType.REGISTER_NAMESPACE) {
-            validateNamespaceCreationTx((NamespaceRegistrationTransaction) transaction, transactionDTO);
+            validateNamespaceCreationTx((NamespaceRegistrationTransaction) transaction,
+                transactionDTO);
         } else if (transaction.getType() == TransactionType.MOSAIC_DEFINITION) {
             validateMosaicCreationTx((MosaicDefinitionTransaction) transaction, transactionDTO);
         } else if (transaction.getType() == TransactionType.MOSAIC_SUPPLY_CHANGE) {

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/TransactionRepositoryVertxImplTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/TransactionRepositoryVertxImplTest.java
@@ -53,7 +53,7 @@ public class TransactionRepositoryVertxImplTest extends AbstractVertxRespository
     @BeforeEach
     public void setUp() {
         super.setUp();
-        repository = new TransactionRepositoryVertxImpl(apiClientMock, networkType);
+        repository = new TransactionRepositoryVertxImpl(apiClientMock, networkType, signSchema);
     }
 
     @Test
@@ -178,7 +178,7 @@ public class TransactionRepositoryVertxImplTest extends AbstractVertxRespository
 
         Account account = Account.createFromPrivateKey(
             "063F36659A8BB01D5685826C19E2C2CA9D281465B642BD5E43CB69510408ECF7",
-            this.networkType.get());
+            this.networkType.get(), signSchema);
 
         Address address =
             Address.createFromRawAddress(

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/VertxAggregateTransactionTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/VertxAggregateTransactionTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.infrastructure.vertx.mappers.GeneralTransactionMapper;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.account.Address;
@@ -52,6 +53,8 @@ public class VertxAggregateTransactionTest {
 
     private final JsonHelper jsonHelper = new JsonHelperJackson2(Json.mapper);
 
+    private SignSchema signSchema = SignSchema.DEFAULT;
+
     @Test
     void createAAggregateTransactionViaStaticConstructor() {
 
@@ -73,7 +76,7 @@ public class VertxAggregateTransactionTest {
                     transferTx.toAggregate(
                         new PublicAccount(
                             "9A49366406ACA952B88BADF5F1E9BE6CE4968141035A60BE503273EA65456B24",
-                            NetworkType.MIJIN_TEST))),
+                            NetworkType.MIJIN_TEST, signSchema))),
                 NetworkType.MIJIN_TEST);
 
         assertEquals(NetworkType.MIJIN_TEST, aggregateTx.getNetworkType());
@@ -108,7 +111,7 @@ public class VertxAggregateTransactionTest {
                     transferTx.toAggregate(
                         new PublicAccount(
                             "846B4439154579A5903B1459C9CF69CB8153F6D0110A7A0ED61DE29AE4810BF2",
-                            NetworkType.MIJIN_TEST))),
+                            NetworkType.MIJIN_TEST, SignSchema.DEFAULT))),
                 NetworkType.MIJIN_TEST);
 
         byte[] actual = aggregateTx.generateBytes();
@@ -135,17 +138,17 @@ public class VertxAggregateTransactionTest {
                     transferTx.toAggregate(
                         new PublicAccount(
                             "B694186EE4AB0558CA4AFCFDD43B42114AE71094F5A1FC4A913FE9971CACD21D",
-                            NetworkType.MIJIN_TEST))),
+                            NetworkType.MIJIN_TEST, signSchema))),
                 NetworkType.MIJIN_TEST);
 
         Account cosignatoryAccount =
             new Account(
                 "2a2b1f5d366a5dd5dc56c3c757cf4fe6c66e2787087692cf329d7a49a594658b",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
         Account cosignatoryAccount2 =
             new Account(
                 "b8afae6f4ad13a1b8aad047b488e0738a437c7389d4ff30c359ac068910c1d59",
-                NetworkType.MIJIN_TEST); // TODO bug with private key
+                NetworkType.MIJIN_TEST, signSchema); // TODO bug with private key
 
         SignedTransaction signedTransaction =
             cosignatoryAccount.signTransactionWithCosignatories(
@@ -163,24 +166,24 @@ public class VertxAggregateTransactionTest {
             "shouldFindAccountInAsASignerOfTheTransaction.json");
 
         AggregateTransaction aggregateTransferTransaction =
-            (AggregateTransaction) new GeneralTransactionMapper(jsonHelper)
+            (AggregateTransaction) new GeneralTransactionMapper(jsonHelper, signSchema)
                 .map(aggregateTransferTransactionDTO);
 
         assertTrue(
             aggregateTransferTransaction.signedByAccount(
                 PublicAccount.createFromPublicKey(
                     "A5F82EC8EBB341427B6785C8111906CD0DF18838FB11B51CE0E18B5E79DFF630",
-                    NetworkType.MIJIN_TEST)));
+                    NetworkType.MIJIN_TEST, signSchema)));
         assertTrue(
             aggregateTransferTransaction.signedByAccount(
                 PublicAccount.createFromPublicKey(
                     "7681ED5023141D9CDCF184E5A7B60B7D466739918ED5DA30F7E71EA7B86EFF2D",
-                    NetworkType.MIJIN_TEST)));
+                    NetworkType.MIJIN_TEST, signSchema)));
         assertFalse(
             aggregateTransferTransaction.signedByAccount(
                 PublicAccount.createFromPublicKey(
                     "B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF",
-                    NetworkType.MIJIN_TEST)));
+                    NetworkType.MIJIN_TEST, signSchema)));
     }
 
 

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/VertxCosignatureTransactionTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/VertxCosignatureTransactionTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.crypto.SignSchema;
 import io.nem.sdk.infrastructure.vertx.mappers.GeneralTransactionMapper;
 import io.nem.sdk.model.account.Account;
 import io.nem.sdk.model.blockchain.NetworkType;
@@ -44,12 +45,14 @@ public class VertxCosignatureTransactionTest {
     private final JsonHelper jsonHelper = new JsonHelperJackson2(
         JsonHelperJackson2.configureMapper(Json.mapper));
 
+    private static SignSchema signSchema = SignSchema.DEFAULT;
+
     @BeforeAll
     public static void setup() {
         account =
             new Account(
                 "26b64cb10f005e5988a36744ca19e20d835ccc7c105aaa5f3b212da593180930",
-                NetworkType.MIJIN_TEST);
+                NetworkType.MIJIN_TEST, signSchema);
     }
 
     @Test
@@ -57,7 +60,7 @@ public class VertxCosignatureTransactionTest {
         TransactionInfoDTO transactionInfoDTO = loadCosignatureTransactionInfoDTO(
             "createACosignatureTransactionViaConstructor.json");
         AggregateTransaction aggregateTransaction =
-            (AggregateTransaction) new GeneralTransactionMapper(jsonHelper)
+            (AggregateTransaction) new GeneralTransactionMapper(jsonHelper, signSchema)
                 .map(transactionInfoDTO);
 
         CosignatureTransaction cosignatureTransaction =


### PR DESCRIPTION
Hi Steve, 

This is the first implementation of SignSchema. I haven't added any parameter default so we don't miss any part of the production code that needs to know that configuration. Most unit tests use the sha3 and I added unit tests to the keccak where it applies. I used examples from the test data and your ts specs to validate the generation. 

A future improvement would be to load the sign schema from rest when they provide that data.

Please note that https://github.com/nemtech/nem2-sdk-java/pull/106 adds more Unit Tests, especially around the transaction mappers. There would be some merging effort.

Cheers
