### PR TITLE
JS-52 Non negative namespace ids.

### DIFF
--- a/sdk-core/src/main/java/io/nem/core/utils/ConvertUtils.java
+++ b/sdk-core/src/main/java/io/nem/core/utils/ConvertUtils.java
@@ -145,7 +145,18 @@ public class ConvertUtils {
      * @return the positive {@link BigInteger}.
      */
     public static BigInteger toUnsignedBigInteger(long value) {
-        return BigInteger.valueOf(value).and(UNSIGNED_LONG_MASK);
+        return toUnsignedBigInteger(BigInteger.valueOf(value));
+    }
+
+    /**
+     * It converts a signed BigInteger into an unsigned BigInteger. It fixes overflow problems that
+     * could happen when working with unsigned int 64.
+     *
+     * @param value the value, positive or negative.
+     * @return the positive {@link BigInteger}.
+     */
+    public static BigInteger toUnsignedBigInteger(BigInteger value) {
+        return value.and(UNSIGNED_LONG_MASK);
     }
 
     /**

--- a/sdk-core/src/main/java/io/nem/sdk/model/namespace/NamespaceId.java
+++ b/sdk-core/src/main/java/io/nem/sdk/model/namespace/NamespaceId.java
@@ -52,7 +52,7 @@ public class NamespaceId implements UnresolvedMosaicId, UnresolvedAddress {
     }
 
     private NamespaceId(BigInteger id, Optional<String> fullName) {
-        this.id = id;
+        this.id = ConvertUtils.toUnsignedBigInteger(id);
         this.fullName = fullName;
     }
 

--- a/sdk-core/src/test/java/io/nem/sdk/model/namespace/NamespaceIdTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/namespace/NamespaceIdTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.nem.core.utils.ConvertUtils;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.stream.Stream;
@@ -44,10 +45,35 @@ class NamespaceIdTest {
 
     @ParameterizedTest
     @MethodSource("provider")
-    void createNamespaceIdsFromUInt64LowerAndHigher(
+    void createNamespaceIdsFromLong(
         String expectedIdAsHex, long idAsLong) {
         NamespaceId namespaceId = NamespaceId.createFromId(BigInteger.valueOf(idAsLong));
         assertEquals(expectedIdAsHex, namespaceId.getIdAsHex());
+        assertEquals(idAsLong, namespaceId.getIdAsLong());
+        assertTrue(namespaceId.getId().compareTo(BigInteger.ZERO) > 0);
+        assertEquals(ConvertUtils.toUnsignedBigInteger(idAsLong), namespaceId.getId());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provider")
+    void createNamespaceIdsFromBigInteger(
+        String expectedIdAsHex, long idAsLong) {
+        NamespaceId namespaceId = NamespaceId
+            .createFromId(ConvertUtils.toUnsignedBigInteger(idAsLong));
+        assertEquals(expectedIdAsHex, namespaceId.getIdAsHex());
+        assertEquals(idAsLong, namespaceId.getIdAsLong());
+        assertTrue(namespaceId.getId().compareTo(BigInteger.ZERO) > 0);
+        assertEquals(ConvertUtils.toUnsignedBigInteger(idAsLong), namespaceId.getId());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provider")
+    void createNamespaceIdsFromHex(String hex, long idAsLong) {
+        NamespaceId namespaceId = NamespaceId.createFromId(new BigInteger(hex, 16));
+        assertEquals(hex, namespaceId.getIdAsHex());
+        assertEquals(idAsLong, namespaceId.getIdAsLong());
+        assertTrue(namespaceId.getId().compareTo(BigInteger.ZERO) > 0);
+        assertEquals(ConvertUtils.toUnsignedBigInteger(idAsLong), namespaceId.getId());
     }
 
     @Test
@@ -104,7 +130,8 @@ class NamespaceIdTest {
     @Test
     void createANamespaceIdFromIdViaConstructor() {
         NamespaceId namespaceId = NamespaceId.createFromId(new BigInteger("-8884663987180930485"));
-        assertEquals(namespaceId.getId(), new BigInteger("-8884663987180930485"));
+        assertEquals(namespaceId.getId(),
+            ConvertUtils.toUnsignedBigInteger(new BigInteger("-8884663987180930485")));
         assertFalse(namespaceId.getFullName().isPresent());
     }
 

--- a/sdk-core/src/test/java/io/nem/sdk/model/namespace/NamespaceInfoTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/namespace/NamespaceInfoTest.java
@@ -72,13 +72,13 @@ class NamespaceInfoTest {
     @Test
     void shouldReturnRootNamespaceId() {
         NamespaceInfo namespaceInfo = createRootNamespaceInfo();
-        assertEquals(new BigInteger("-8884663987180930485"), namespaceInfo.getId().getId());
+        assertEquals(new BigInteger("9562080086528621131"), namespaceInfo.getId().getId());
     }
 
     @Test
     void shouldReturnSubNamespaceId() {
         NamespaceInfo namespaceInfo = createSubNamespaceInfo();
-        assertEquals(new BigInteger("-1087871471161192663"), namespaceInfo.getId().getId());
+        assertEquals(new BigInteger("17358872602548358953"), namespaceInfo.getId().getId());
     }
 
     @Test
@@ -108,7 +108,7 @@ class NamespaceInfoTest {
     @Test
     void shouldReturnParentNamespaceIdWhenNamespaceInfoIsFromSubNamespace() {
         NamespaceInfo namespaceInfo = createSubNamespaceInfo();
-        assertEquals(new BigInteger("-3087871471161192663"),
+        assertEquals(new BigInteger("15358872602548358953"),
             namespaceInfo.parentNamespaceId().getId());
     }
 
@@ -149,7 +149,7 @@ class NamespaceInfoTest {
             NamespaceRegistrationType.SUB_NAMESPACE,
             1,
             Arrays.asList(
-                NamespaceId.createFromId(new BigInteger("-3087871471161192663")),
+                NamespaceId.createFromId(new BigInteger("17358872602548358953")),
                 NamespaceId.createFromId(new BigInteger("-1087871471161192663"))),
             NamespaceId.createFromId(new BigInteger("-3087871471161192663")),
             new PublicAccount(

--- a/sdk-core/src/test/java/io/nem/sdk/model/receipt/ArtifactExpiryReceiptTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/receipt/ArtifactExpiryReceiptTest.java
@@ -48,7 +48,7 @@ public class ArtifactExpiryReceiptTest {
 
     @Test
     void shouldCreateNamespaceExpiryReceipt() {
-        NamespaceId namespaceId = NamespaceId.createFromId(new BigInteger("-8884663987180930485"));
+        NamespaceId namespaceId = NamespaceId.createFromId(new BigInteger("9562080086528621131"));
         ArtifactExpiryReceipt<NamespaceId> namespaceExpiryReceipt =
             new ArtifactExpiryReceipt<>(
                 namespaceId, ReceiptType.NAMESPACE_EXPIRED, ReceiptVersion.ARTIFACT_EXPIRY);
@@ -56,7 +56,7 @@ public class ArtifactExpiryReceiptTest {
         assertFalse(namespaceExpiryReceipt.getSize().isPresent());
         assertEquals(ReceiptVersion.ARTIFACT_EXPIRY, namespaceExpiryReceipt.getVersion());
         assertEquals(
-            namespaceExpiryReceipt.getArtifactId().getId(), new BigInteger("-8884663987180930485"));
+            namespaceExpiryReceipt.getArtifactId().getId(), new BigInteger("9562080086528621131"));
 
         String hex = Hex.toHexString(namespaceExpiryReceipt.serialize());
         Assertions.assertEquals("01004e414bfa5f372d55b384", hex);


### PR DESCRIPTION
Hi @fullcircle23 

This is a quick one. The idea is that namespace big integer ids should not be negative (although the long id may overflow bing a negative value). 