### PR TITLE
f3 epoch adjustment

### DIFF
--- a/sdk-core/src/main/java/io/nem/sdk/model/transaction/Deadline.java
+++ b/sdk-core/src/main/java/io/nem/sdk/model/transaction/Deadline.java
@@ -34,7 +34,7 @@ public class Deadline {
     /**
      * Nemesis block timestamp.
      */
-    private static final Instant TIMESTAMP_NEMSIS_BLOCK = Instant.ofEpochSecond(1459468800);
+    private static final Instant TIMESTAMP_NEMESIS_BLOCK = Instant.ofEpochSecond(1573426800);
 
     private final Instant instant;
 
@@ -56,15 +56,14 @@ public class Deadline {
     public Deadline(BigInteger input) {
         instant =
             Instant
-                .ofEpochMilli(input.longValue() + Deadline.TIMESTAMP_NEMSIS_BLOCK.toEpochMilli());
+                .ofEpochMilli(input.longValue() + Deadline.TIMESTAMP_NEMESIS_BLOCK.toEpochMilli());
     }
 
     /**
      * @return the BigInteger representation of the duration.
      */
     public BigInteger toBigInteger() {
-        return BigInteger
-            .valueOf(instant.toEpochMilli() - Deadline.TIMESTAMP_NEMSIS_BLOCK.toEpochMilli());
+        return BigInteger.valueOf(getInstant());
     }
 
     /**
@@ -93,7 +92,7 @@ public class Deadline {
      * @return long
      */
     public long getInstant() {
-        return instant.toEpochMilli() - Deadline.TIMESTAMP_NEMSIS_BLOCK.toEpochMilli();
+        return instant.toEpochMilli() - Deadline.TIMESTAMP_NEMESIS_BLOCK.toEpochMilli();
     }
 
     /**

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/DeadlineTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/DeadlineTest.java
@@ -30,7 +30,7 @@ class DeadlineTest {
     @Test
     void shouldCreateADeadlineForTwoHoursFromNow() {
         LocalDateTime now = LocalDateTime.now(ZoneId.systemDefault());
-        Deadline deadline = new Deadline(2, ChronoUnit.HOURS);
+        Deadline deadline = Deadline.create();
         assertTrue(now.isBefore(deadline.getLocalDateTime()), "now is before deadline localtime");
         assertTrue(
             now.plusHours(2).minusSeconds(1).isBefore(deadline.getLocalDateTime()),

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/MosaicGlobalRestrictionTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/MosaicGlobalRestrictionTransactionTest.java
@@ -63,7 +63,7 @@ class MosaicGlobalRestrictionTransactionTest extends AbstractTransactionTester {
             .signWith(account, generationHash);
 
         assertEquals(
-            "1B000000010000000000000002000000000000000100000000000000090000000000000008000000000000000106",
+            "00000000010000000000000002000000000000000100000000000000090000000000000008000000000000000106",
             signedTransaction.getPayload().substring(248));
     }
 

--- a/sdk-core/src/test/java/io/nem/sdk/model/transaction/NamespaceRegistrationTransactionTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/transaction/NamespaceRegistrationTransactionTest.java
@@ -54,7 +54,7 @@ class NamespaceRegistrationTransactionTest extends AbstractTransactionTester {
             namespaceRegistrationTransaction.signWith(testAccount, generationHash);
 
         assertEquals(
-            "1B000000E803000000000000CFCBE72D994BE69B0013726F6F742D746573742D6E616D657370616365",
+            "00000000E803000000000000CFCBE72D994BE69B0013726F6F742D746573742D6E616D657370616365",
             signedTransaction.getPayload().substring(248)
         );
         assertEquals(networkType, namespaceRegistrationTransaction.getNetworkType());
@@ -86,7 +86,7 @@ class NamespaceRegistrationTransactionTest extends AbstractTransactionTester {
             namespaceRegistrationTransaction.signWith(testAccount, generationHash);
 
         assertEquals(
-            "1B0000004DF55E7F6D8FB7FF924207DF2CA1BBF30113726F6F742D746573742D6E616D657370616365",
+            "000000004DF55E7F6D8FB7FF924207DF2CA1BBF30113726F6F742D746573742D6E616D657370616365",
             signedTransaction.getPayload().substring(248));
         assertEquals(networkType, namespaceRegistrationTransaction.getNetworkType());
         assertTrue(1 == namespaceRegistrationTransaction.getVersion());
@@ -116,7 +116,7 @@ class NamespaceRegistrationTransactionTest extends AbstractTransactionTester {
             namespaceRegistrationTransaction.signWith(testAccount, generationHash);
 
         assertEquals(
-            "1B0000004DF55E7F6D8FB7FF924207DF2CA1BBF30113726F6F742D746573742D6E616D657370616365",
+            "000000004DF55E7F6D8FB7FF924207DF2CA1BBF30113726F6F742D746573742D6E616D657370616365",
             signedTransaction.getPayload().substring(248));
         assertEquals(networkType, namespaceRegistrationTransaction.getNetworkType());
         assertTrue(1 == namespaceRegistrationTransaction.getVersion());

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/OkHttpAggregateTransactionTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/OkHttpAggregateTransactionTest.java
@@ -64,7 +64,7 @@ public class OkHttpAggregateTransactionTest {
 
         AggregateTransaction aggregateTx =
             AggregateTransactionFactory.createComplete(NetworkType.MIJIN_TEST,
-                Arrays.asList(
+                Collections.singletonList(
                     transferTx.toAggregate(
                         new PublicAccount(
                             "9A49366406ACA952B88BADF5F1E9BE6CE4968141035A60BE503273EA65456B24",
@@ -140,7 +140,7 @@ public class OkHttpAggregateTransactionTest {
                 aggregateTx, Collections.singletonList(cosignatoryAccount2), generationHash);
 
         assertEquals("6801000000000000", signedTransaction.getPayload().substring(0, 16));
-        assertEquals("1b000000d6a52a97", signedTransaction.getPayload().substring(248, 264));
+        assertEquals("00000000d6a52a97", signedTransaction.getPayload().substring(248, 264));
 
     }
 

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/VertxAggregateTransactionTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/VertxAggregateTransactionTest.java
@@ -143,7 +143,7 @@ public class VertxAggregateTransactionTest {
                 aggregateTx, Collections.singletonList(cosignatoryAccount2), generationHash);
 
         assertEquals("6801000000000000", signedTransaction.getPayload().substring(0, 16));
-        assertEquals("1b000000d6a52a97", signedTransaction.getPayload().substring(248, 264));
+        assertEquals("00000000d6a52a97", signedTransaction.getPayload().substring(248, 264));
         // assertEquals("039054419050B9837EFAB4BBE8A4B9BB32D812F9885C00D8FC1650E1420D000000746573742D6D65737361676568B3FBB18729C1FDE225C57F8CE080FA828F0067E451A3FD81FA628842B0B763", signedTransaction.getPayload().substring(320, 474));
 
     }


### PR DESCRIPTION
Changes the Deadline.timestampNemesisBlock property to be 0.9.1.1 compatible

Keeping it consistent with TS.

https://github.com/nemtech/nem2-sdk-typescript-javascript/pull/371