### PR TITLE
Implemented MosaicRestrictionTransactionService

### DIFF
--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountMetadataIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountMetadataIntegrationTest.java
@@ -64,7 +64,7 @@ public class AccountMetadataIntegrationTest extends BaseIntegrationTest {
         Assertions.assertEquals(transaction.getScopedMetadataKey(),
             processedTransaction.getScopedMetadataKey());
 
-        sleep(2000);
+       // sleep(2000);
 
         Metadata metadata = assertMetadata(transaction,
             get(getRepositoryFactory(type).createMetadataRepository()

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountMetadataIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountMetadataIntegrationTest.java
@@ -64,8 +64,6 @@ public class AccountMetadataIntegrationTest extends BaseIntegrationTest {
         Assertions.assertEquals(transaction.getScopedMetadataKey(),
             processedTransaction.getScopedMetadataKey());
 
-       // sleep(2000);
-
         Metadata metadata = assertMetadata(transaction,
             get(getRepositoryFactory(type).createMetadataRepository()
                 .getAccountMetadata(testAccount.getAddress(),

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountMetadataServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountMetadataServiceIntegrationTest.java
@@ -53,7 +53,7 @@ class AccountMetadataServiceIntegrationTest extends BaseIntegrationTest {
             repositoryFactory);
 
         AccountMetadataTransaction originalTransaction = get(service
-            .createAccountMetadataTransactionFactory(getNetworkType(),
+            .createAccountMetadataTransactionFactory(
                 targetAccount.getPublicAccount(), key, originalMessage,
                 signerAccount.getPublicAccount().getPublicKey())).maxFee(this.maxFee).build();
 
@@ -64,7 +64,7 @@ class AccountMetadataServiceIntegrationTest extends BaseIntegrationTest {
         assertMetadata(key, originalMessage, metadataRepository);
 
         AccountMetadataTransaction updateTransaction = get(service
-            .createAccountMetadataTransactionFactory(getNetworkType(),
+            .createAccountMetadataTransactionFactory(
                 targetAccount.getPublicAccount(), key, newMessage,
                 signerAccount.getPublicAccount().getPublicKey())).maxFee(this.maxFee).build();
 

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountMetadataServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountMetadataServiceIntegrationTest.java
@@ -59,8 +59,6 @@ class AccountMetadataServiceIntegrationTest extends BaseIntegrationTest {
 
         announceAggregateAndValidate(type, originalTransaction, signerAccount);
 
-        sleep(2000);
-
         assertMetadata(key, originalMessage, metadataRepository);
 
         AccountMetadataTransaction updateTransaction = get(service
@@ -69,8 +67,6 @@ class AccountMetadataServiceIntegrationTest extends BaseIntegrationTest {
                 signerAccount.getPublicAccount().getPublicKey())).maxFee(this.maxFee).build();
 
         announceAggregateAndValidate(type, updateTransaction, signerAccount);
-
-        sleep(2000);
 
         assertMetadata(key, newMessage, metadataRepository);
 

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountRestrictionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/AccountRestrictionIntegrationTest.java
@@ -71,7 +71,8 @@ class AccountRestrictionIntegrationTest extends BaseIntegrationTest {
         System.out.println("Removing transaction restriction");
         sendAccountRestrictionTransaction(type, transactionType, false, restrictionFlags);
 
-        Assertions.assertFalse(hasRestriction(type, testAccount, restrictionFlags, transactionType));
+        Assertions
+            .assertFalse(hasRestriction(type, testAccount, restrictionFlags, transactionType));
 
     }
 
@@ -143,7 +144,6 @@ class AccountRestrictionIntegrationTest extends BaseIntegrationTest {
     private boolean hasRestriction(RepositoryType type, Account testAccount,
         AccountRestrictionFlags restrictionFlags, Object value) {
         try {
-            sleep(2000);//Need to wait?
             AccountRestrictions restrictions = get(
                 getRepositoryFactory(type).createRestrictionAccountRepository()
                     .getAccountRestrictions(testAccount.getAddress()));
@@ -154,7 +154,7 @@ class AccountRestrictionIntegrationTest extends BaseIntegrationTest {
                 r -> r.getRestrictionFlags()
                     .equals(restrictionFlags) && r.getValues()
                     .contains(value));
-        } catch (RepositoryCallException | InterruptedException e) {
+        } catch (Exception e) {
             //If it fails, it's because is a new account.
             Assertions.assertEquals(
                 "ApiException: Not Found - 404 - ResourceNotFound - no resource exists with id '"
@@ -185,7 +185,8 @@ class AccountRestrictionIntegrationTest extends BaseIntegrationTest {
         AccountOperationRestrictionTransaction processedTransaction = announceAndValidate(type,
             testAccount, transaction);
 
-        Assertions.assertEquals(accountRestrictionFlags, processedTransaction.getRestrictionFlags());
+        Assertions
+            .assertEquals(accountRestrictionFlags, processedTransaction.getRestrictionFlags());
         Assertions.assertEquals(additions, processedTransaction.getRestrictionAdditions());
         Assertions.assertEquals(deletions, processedTransaction.getRestrictionDeletions());
     }
@@ -210,7 +211,8 @@ class AccountRestrictionIntegrationTest extends BaseIntegrationTest {
         AccountMosaicRestrictionTransaction processedTransaction = announceAndValidate(type,
             testAccount, transaction);
 
-        Assertions.assertEquals(accountRestrictionFlags, processedTransaction.getRestrictionFlags());
+        Assertions
+            .assertEquals(accountRestrictionFlags, processedTransaction.getRestrictionFlags());
         Assertions.assertEquals(additions, processedTransaction.getRestrictionAdditions());
         Assertions.assertEquals(deletions, processedTransaction.getRestrictionDeletions());
     }
@@ -235,8 +237,10 @@ class AccountRestrictionIntegrationTest extends BaseIntegrationTest {
         AccountAddressRestrictionTransaction processedTransaction = announceAndValidate(type,
             testAccount, transaction);
 
-        Assertions.assertEquals(accountRestrictionFlags, processedTransaction.getRestrictionFlags());
-        Assertions.assertEquals(accountRestrictionFlags, processedTransaction.getRestrictionFlags());
+        Assertions
+            .assertEquals(accountRestrictionFlags, processedTransaction.getRestrictionFlags());
+        Assertions
+            .assertEquals(accountRestrictionFlags, processedTransaction.getRestrictionFlags());
         Assertions.assertEquals(additions, processedTransaction.getRestrictionAdditions());
         Assertions.assertEquals(deletions, processedTransaction.getRestrictionDeletions());
 
@@ -249,7 +253,8 @@ class AccountRestrictionIntegrationTest extends BaseIntegrationTest {
             .createFromPublicKey("67F69FA4BFCD158F6E1AF1ABC82F725F5C5C4710D6E29217B12BE66397435DFB",
                 getNetworkType());
 
-        RestrictionAccountRepository repository = getRepositoryFactory(type).createRestrictionAccountRepository();
+        RestrictionAccountRepository repository = getRepositoryFactory(type)
+            .createRestrictionAccountRepository();
         Assertions.assertEquals(0, get(repository
             .getAccountsRestrictions(
                 Collections.singletonList(address))).size());
@@ -258,7 +263,8 @@ class AccountRestrictionIntegrationTest extends BaseIntegrationTest {
     @ParameterizedTest
     @EnumSource(RepositoryType.class)
     void getAccountRestrictionsWhenAccountDoesNotExist(RepositoryType type) {
-        RestrictionAccountRepository repository = getRepositoryFactory(type).createRestrictionAccountRepository();
+        RestrictionAccountRepository repository = getRepositoryFactory(type)
+            .createRestrictionAccountRepository();
 
         Address address = Address
             .createFromPublicKey("67F69FA4BFCD158F6E1AF1ABC82F725F5C5C4710D6E29217B12BE66397435DFB",

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/AddressAliasTransactionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/AddressAliasTransactionIntegrationTest.java
@@ -60,7 +60,6 @@ public class AddressAliasTransactionIntegrationTest extends BaseIntegrationTest 
         NamespaceId rootNamespaceId = announceAggregateAndValidate(type,
             namespaceRegistrationTransaction, account
         ).getLeft().getNamespaceId();
-        sleep(1000);
 
         AddressAliasTransaction addressAliasTransaction =
             AddressAliasTransactionFactory.create(getNetworkType(),
@@ -77,8 +76,6 @@ public class AddressAliasTransactionIntegrationTest extends BaseIntegrationTest 
             ).maxFee(this.maxFee).build();
 
         announceAndValidate(type, account, aggregateTransaction2);
-
-        sleep(1000);
 
         List<AccountNames> accountNames = get(getRepositoryFactory(type).createNamespaceRepository()
             .getAccountsNames(Collections.singletonList(account.getAddress())));

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/BaseIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/BaseIntegrationTest.java
@@ -326,6 +326,7 @@ public abstract class BaseIntegrationTest {
 
     @SuppressWarnings("squid:S2925")
     protected void sleep(long time) throws InterruptedException {
+        System.out.println("Sleeping for " + time);
         Thread.sleep(time);
     }
 
@@ -443,8 +444,6 @@ public abstract class BaseIntegrationTest {
 
             NamespaceId rootNamespaceId = createRootNamespace(type, account, alias);
             unresolvedMosaicId = rootNamespaceId;
-
-            sleep(1000);
 
             MosaicAliasTransaction addressAliasTransaction =
                 MosaicAliasTransactionFactory.create(

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicAddressRestrictionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicAddressRestrictionIntegrationTest.java
@@ -87,7 +87,6 @@ public class MosaicAddressRestrictionIntegrationTest extends BaseIntegrationTest
             type, createTransaction, testAccount).getLeft());
 
         //5) Validate that endpoints have the data.
-       // sleep(1000);
 
         RestrictionMosaicRepository restrictionRepository = getRepositoryFactory(type)
             .createRestrictionMosaicRepository();
@@ -114,8 +113,6 @@ public class MosaicAddressRestrictionIntegrationTest extends BaseIntegrationTest
         //7) Announce and validate.
         assertTransaction(updateTransaction, announceAggregateAndValidate(
             type, updateTransaction, testAccount).getLeft());
-
-        //sleep(1000);
 
         //8) Validates that the endpoints have the new values
         assertMosaicAddressRestriction(targetAddress, updateTransaction, get(

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicAddressRestrictionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicAddressRestrictionIntegrationTest.java
@@ -45,8 +45,7 @@ public class MosaicAddressRestrictionIntegrationTest extends BaseIntegrationTest
 
     private Account testAccount = config().getDefaultAccount();
     private Account testAccount2 = config().getTestAccount2();
-
-    BigInteger restrictionKey = BigInteger.valueOf(22222);
+    private BigInteger restrictionKey = BigInteger.valueOf(22222);
 
     @ParameterizedTest
     @EnumSource(RepositoryType.class)

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicAddressRestrictionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicAddressRestrictionIntegrationTest.java
@@ -87,7 +87,7 @@ public class MosaicAddressRestrictionIntegrationTest extends BaseIntegrationTest
             type, createTransaction, testAccount).getLeft());
 
         //5) Validate that endpoints have the data.
-        sleep(1000);
+       // sleep(1000);
 
         RestrictionMosaicRepository restrictionRepository = getRepositoryFactory(type)
             .createRestrictionMosaicRepository();
@@ -115,7 +115,7 @@ public class MosaicAddressRestrictionIntegrationTest extends BaseIntegrationTest
         assertTransaction(updateTransaction, announceAggregateAndValidate(
             type, updateTransaction, testAccount).getLeft());
 
-        sleep(1000);
+        //sleep(1000);
 
         //8) Validates that the endpoints have the new values
         assertMosaicAddressRestriction(targetAddress, updateTransaction, get(

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicAliasTransactionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicAliasTransactionIntegrationTest.java
@@ -67,8 +67,6 @@ public class MosaicAliasTransactionIntegrationTest extends BaseIntegrationTest {
             namespaceRegistrationTransaction, account
         ).getLeft().getNamespaceId();
 
-        sleep(1000);
-
         MosaicAliasTransaction addressAliasTransaction =
             MosaicAliasTransactionFactory.create(
                 getNetworkType(),
@@ -78,7 +76,6 @@ public class MosaicAliasTransactionIntegrationTest extends BaseIntegrationTest {
 
         announceAggregateAndValidate(type, addressAliasTransaction, account);
 
-        sleep(2000);
 
         List<MosaicNames> accountNames = get(getRepositoryFactory(type).createNamespaceRepository()
             .getMosaicsNames(Collections.singletonList(mosaicId)));

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicGlobalRestrictionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicGlobalRestrictionIntegrationTest.java
@@ -47,10 +47,10 @@ public class MosaicGlobalRestrictionIntegrationTest extends BaseIntegrationTest 
 
         //1) Create a new mosaic
 
-        String masaicAliasName = "MosaicRestrictionServiceIntegrationTest_createMosaicGlobalRestrictionAndValidateEndpoints"
+        String mosaicAliasName = "MosaicRestrictionServiceIntegrationTest_createMosaicGlobalRestrictionAndValidateEndpoints"
             .toLowerCase();
-        NamespaceId mosaicAlias = NamespaceId.createFromName(masaicAliasName);
-        MosaicId mosaicId = createMosaic(testAccount, type, null, masaicAliasName);
+        NamespaceId mosaicAlias = NamespaceId.createFromName(mosaicAliasName);
+        MosaicId mosaicId = createMosaic(testAccount, type, null, mosaicAliasName);
 
         //2) Create a restriction on the mosaic
 

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicGlobalRestrictionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicGlobalRestrictionIntegrationTest.java
@@ -37,7 +37,7 @@ public class MosaicGlobalRestrictionIntegrationTest extends BaseIntegrationTest 
 
     private Account testAccount = config().getDefaultAccount();
 
-    private  BigInteger restrictionKey = BigInteger.valueOf(11111);
+    private BigInteger restrictionKey = BigInteger.valueOf(11111);
 
 
     @ParameterizedTest
@@ -72,7 +72,6 @@ public class MosaicGlobalRestrictionIntegrationTest extends BaseIntegrationTest 
         assertTransaction(createTransaction, processedCreateTransaction);
 
         //5) Validate the data from the endpoints
-        sleep(1000);
 
         RestrictionMosaicRepository restrictionRepository = getRepositoryFactory(type)
             .createRestrictionMosaicRepository();
@@ -102,7 +101,6 @@ public class MosaicGlobalRestrictionIntegrationTest extends BaseIntegrationTest 
         assertTransaction(updateTransaction, processedUpdateTransaction);
 
         //8) Validating that the endpoints show the new value and type.
-        sleep(1000);
 
         assertMosaicGlobalRestriction(updateTransaction, get(
             restrictionRepository.getMosaicGlobalRestriction(mosaicId)));

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicGlobalRestrictionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicGlobalRestrictionIntegrationTest.java
@@ -19,14 +19,9 @@ package io.nem.sdk.infrastructure;
 import io.nem.sdk.api.RepositoryCallException;
 import io.nem.sdk.api.RestrictionMosaicRepository;
 import io.nem.sdk.model.account.Account;
-import io.nem.sdk.model.blockchain.BlockDuration;
-import io.nem.sdk.model.mosaic.MosaicFlags;
 import io.nem.sdk.model.mosaic.MosaicId;
-import io.nem.sdk.model.mosaic.MosaicNonce;
 import io.nem.sdk.model.namespace.NamespaceId;
 import io.nem.sdk.model.restriction.MosaicGlobalRestriction;
-import io.nem.sdk.model.transaction.MosaicDefinitionTransaction;
-import io.nem.sdk.model.transaction.MosaicDefinitionTransactionFactory;
 import io.nem.sdk.model.transaction.MosaicGlobalRestrictionTransaction;
 import io.nem.sdk.model.transaction.MosaicGlobalRestrictionTransactionFactory;
 import io.nem.sdk.model.transaction.MosaicRestrictionType;
@@ -40,9 +35,10 @@ import org.junit.jupiter.params.provider.EnumSource;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MosaicGlobalRestrictionIntegrationTest extends BaseIntegrationTest {
 
-    Account testAccount = config().getDefaultAccount();
+    private Account testAccount = config().getDefaultAccount();
 
-    BigInteger restrictionKey = BigInteger.valueOf(11111);
+    private  BigInteger restrictionKey = BigInteger.valueOf(11111);
+
 
     @ParameterizedTest
     @EnumSource(RepositoryType.class)
@@ -50,9 +46,11 @@ public class MosaicGlobalRestrictionIntegrationTest extends BaseIntegrationTest 
         throws InterruptedException {
 
         //1) Create a new mosaic
-        MosaicId mosaicId = createMosaic(type);
-        NamespaceId mosaicAlias = setMosaicAlias(type, mosaicId,
-            ("mosaicAlias" + mosaicId.getIdAsHex()).toLowerCase());
+
+        String masaicAliasName = "MosaicRestrictionServiceIntegrationTest_createMosaicGlobalRestrictionAndValidateEndpoints"
+            .toLowerCase();
+        NamespaceId mosaicAlias = NamespaceId.createFromName(masaicAliasName);
+        MosaicId mosaicId = createMosaic(testAccount, type, null, masaicAliasName);
 
         //2) Create a restriction on the mosaic
 
@@ -115,6 +113,7 @@ public class MosaicGlobalRestrictionIntegrationTest extends BaseIntegrationTest 
 
     }
 
+
     private void assertTransaction(
         MosaicGlobalRestrictionTransaction expectedTransaction,
         MosaicGlobalRestrictionTransaction processedTransaction) {
@@ -170,24 +169,6 @@ public class MosaicGlobalRestrictionIntegrationTest extends BaseIntegrationTest 
                 .getReferenceMosaicId());
     }
 
-    private MosaicId createMosaic(RepositoryType type) {
-        MosaicNonce nonce = MosaicNonce.createRandom();
-        MosaicId mosaicId = MosaicId.createFromNonce(nonce, testAccount.getPublicAccount());
-
-        System.out.println(mosaicId.getIdAsHex());
-
-        MosaicDefinitionTransaction mosaicDefinitionTransaction =
-            MosaicDefinitionTransactionFactory.create(getNetworkType(),
-                nonce,
-                mosaicId,
-                MosaicFlags.create(true, true, true),
-                4, new BlockDuration(100)).maxFee(this.maxFee).build();
-
-        MosaicDefinitionTransaction validateTransaction = announceAndValidate(type,
-            testAccount, mosaicDefinitionTransaction);
-        Assertions.assertEquals(mosaicId, validateTransaction.getMosaicId());
-        return mosaicId;
-    }
 
     @ParameterizedTest
     @EnumSource(RepositoryType.class)

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicIdMetadataServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicIdMetadataServiceIntegrationTest.java
@@ -65,8 +65,6 @@ class MosaicIdMetadataServiceIntegrationTest extends BaseIntegrationTest {
 
         announceAggregateAndValidate(type, originalTransaction, signerAccount);
 
-        sleep(2000);
-
         assertMetadata(targetMosaicId, key, originalMessage, metadataRepository);
 
         MosaicMetadataTransaction updateTransaction = get(service
@@ -76,8 +74,6 @@ class MosaicIdMetadataServiceIntegrationTest extends BaseIntegrationTest {
             .maxFee(this.maxFee).build();
 
         announceAggregateAndValidate(type, updateTransaction, signerAccount);
-
-        sleep(2000);
 
         assertMetadata(targetMosaicId, key, newMessage, metadataRepository);
 

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicIdMetadataServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicIdMetadataServiceIntegrationTest.java
@@ -58,7 +58,7 @@ class MosaicIdMetadataServiceIntegrationTest extends BaseIntegrationTest {
             repositoryFactory);
 
         MosaicMetadataTransaction originalTransaction = get(service
-            .createMosaicMetadataTransactionFactory(getNetworkType(),
+            .createMosaicMetadataTransactionFactory(
                 targetAccount.getPublicAccount(), key, originalMessage,
                 signerAccount.getPublicAccount().getPublicKey(), targetMosaicId))
             .maxFee(this.maxFee).build();
@@ -70,7 +70,7 @@ class MosaicIdMetadataServiceIntegrationTest extends BaseIntegrationTest {
         assertMetadata(targetMosaicId, key, originalMessage, metadataRepository);
 
         MosaicMetadataTransaction updateTransaction = get(service
-            .createMosaicMetadataTransactionFactory(getNetworkType(),
+            .createMosaicMetadataTransactionFactory(
                 targetAccount.getPublicAccount(), key, newMessage,
                 signerAccount.getPublicAccount().getPublicKey(), targetMosaicId))
             .maxFee(this.maxFee).build();

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicMetadataIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicMetadataIntegrationTest.java
@@ -85,7 +85,6 @@ public class MosaicMetadataIntegrationTest extends BaseIntegrationTest {
         Assertions.assertEquals(transaction.getScopedMetadataKey(),
             processedTransaction.getScopedMetadataKey());
 
-        sleep(2000);
         List<Metadata> metadata = get(getRepositoryFactory(type).createMetadataRepository()
             .getMosaicMetadata(targetMosaicId,
                 Optional.empty()));

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicRepositoryIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicRepositoryIntegrationTest.java
@@ -46,10 +46,9 @@ class MosaicRepositoryIntegrationTest extends BaseIntegrationTest {
     private MosaicId mosaicId;
 
     @BeforeAll
-    void setup() throws InterruptedException {
+    void setup() {
         mosaicId = createMosaic(DEFAULT_REPOSITORY_TYPE, testAccount);
         mosaicIds.add(mosaicId);
-        sleep(1000);
     }
 
     @ParameterizedTest

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicRestrictionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicRestrictionServiceIntegrationTest.java
@@ -70,7 +70,6 @@ public class MosaicRestrictionServiceIntegrationTest extends BaseIntegrationTest
         assertTransaction(createTransaction, processedCreateTransaction);
 
         //5) Validate the data from the endpoints
-        sleep(1000);
 
         RestrictionMosaicRepository restrictionRepository = getRepositoryFactory(type)
             .createRestrictionMosaicRepository();
@@ -98,7 +97,6 @@ public class MosaicRestrictionServiceIntegrationTest extends BaseIntegrationTest
         assertTransaction(updateTransaction, processedUpdateTransaction);
 
         //8) Validating that the endpoints show the new value and type.
-        sleep(1000);
 
         assertMosaicGlobalRestriction(updateTransaction, get(
             restrictionRepository.getMosaicGlobalRestriction(mosaicId)));
@@ -194,7 +192,6 @@ public class MosaicRestrictionServiceIntegrationTest extends BaseIntegrationTest
         assertTransaction(createTransaction, processedCreateTransaction);
 
         //5) Validate the data from the endpoints
-        sleep(1000);
 
         RestrictionMosaicRepository restrictionRepository = getRepositoryFactory(type)
             .createRestrictionMosaicRepository();
@@ -217,8 +214,6 @@ public class MosaicRestrictionServiceIntegrationTest extends BaseIntegrationTest
 
         announceAndValidate(
             type, testAccount, createAddressTransaction);
-
-        sleep(2000);
 
         //7) Announcing the update restriction transaction and checking the processed one.
         MosaicAddressRestrictionTransaction updateAddressTransaction =
@@ -245,10 +240,10 @@ public class MosaicRestrictionServiceIntegrationTest extends BaseIntegrationTest
         throws InterruptedException {
 
         //1) Create mosaic and alias
-        String masaicAliasName = "createUpdateMosaicAddressRestrictionTransactionFactoryUsingAlias"
+        String mosaicAliasName = "createUpdateMosaicAddressRestrictionTransactionFactoryUsingAlias"
             .toLowerCase();
-        NamespaceId mosaicAlias = NamespaceId.createFromName(masaicAliasName);
-        MosaicId mosaicId = createMosaic(testAccount, type, null, masaicAliasName);
+        NamespaceId mosaicAlias = NamespaceId.createFromName(mosaicAliasName);
+        MosaicId mosaicId = createMosaic(testAccount, type, null, mosaicAliasName);
 
         //2) Create a restriction on the mosaic
 
@@ -272,7 +267,6 @@ public class MosaicRestrictionServiceIntegrationTest extends BaseIntegrationTest
         assertTransaction(createTransaction, processedCreateTransaction);
 
         //5) Validate the data from the endpoints
-        sleep(1000);
 
         RestrictionMosaicRepository restrictionRepository = getRepositoryFactory(type)
             .createRestrictionMosaicRepository();
@@ -295,8 +289,6 @@ public class MosaicRestrictionServiceIntegrationTest extends BaseIntegrationTest
 
         announceAndValidate(
             type, testAccount, createAddressTransaction);
-
-        sleep(2000);
 
         //7) Announcing the update restriction transaction and checking the processed one.
         MosaicAddressRestrictionTransaction updateAddressTransaction =

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicRestrictionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/MosaicRestrictionServiceIntegrationTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nem.sdk.infrastructure;
+
+import io.nem.sdk.api.MosaicRestrictionTransactionService;
+import io.nem.sdk.api.RestrictionMosaicRepository;
+import io.nem.sdk.model.account.Account;
+import io.nem.sdk.model.mosaic.MosaicId;
+import io.nem.sdk.model.namespace.NamespaceId;
+import io.nem.sdk.model.restriction.MosaicGlobalRestriction;
+import io.nem.sdk.model.transaction.MosaicAddressRestrictionTransaction;
+import io.nem.sdk.model.transaction.MosaicGlobalRestrictionTransaction;
+import io.nem.sdk.model.transaction.MosaicRestrictionType;
+import java.math.BigInteger;
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MosaicRestrictionServiceIntegrationTest extends BaseIntegrationTest {
+
+    private Account testAccount = config().getDefaultAccount();
+
+    private BigInteger restrictionKey = BigInteger.valueOf(11111);
+
+
+    @ParameterizedTest
+    @EnumSource(RepositoryType.class)
+    void createUpdateMosaicGlobalRestrictionTransactionFactory(RepositoryType type)
+        throws InterruptedException {
+
+        //1) Create a new mosaic
+        MosaicId mosaicId = createMosaic(testAccount, type, null, null);
+
+        //2) Create a restriction on the mosaic
+
+        MosaicRestrictionTransactionService restrictionService = getMosaicRestrictionTransactionService(
+            type);
+
+        BigInteger originalValue = BigInteger.valueOf(20);
+        MosaicRestrictionType originalRestrictionType = MosaicRestrictionType.GE;
+        MosaicGlobalRestrictionTransaction createTransaction =
+            get(restrictionService.createMosaicGlobalRestrictionTransactionFactory(
+                mosaicId,
+                restrictionKey,
+                originalValue,
+                originalRestrictionType
+            )).maxFee(this.maxFee).build();
+
+        //3) Announce the create restriction transaction
+        MosaicGlobalRestrictionTransaction processedCreateTransaction = announceAndValidate(
+            type, testAccount, createTransaction);
+        //4) Validate that the received processedCreateTransaction and the create transaction are the same
+        assertTransaction(createTransaction, processedCreateTransaction);
+
+        //5) Validate the data from the endpoints
+        sleep(1000);
+
+        RestrictionMosaicRepository restrictionRepository = getRepositoryFactory(type)
+            .createRestrictionMosaicRepository();
+
+        assertMosaicGlobalRestriction(createTransaction, get(
+            restrictionRepository.getMosaicGlobalRestriction(mosaicId)));
+
+        assertMosaicGlobalRestriction(createTransaction, get(
+            restrictionRepository
+                .getMosaicGlobalRestrictions(Collections.singletonList(mosaicId))).get(0));
+
+        // 6) Modifying the restriction by sending a new transaction with the previous values.
+        MosaicGlobalRestrictionTransaction updateTransaction =
+            get(restrictionService.createMosaicGlobalRestrictionTransactionFactory(
+                mosaicId,
+                restrictionKey,
+                BigInteger.valueOf(40),
+                MosaicRestrictionType.EQ
+            )).maxFee(this.maxFee).build();
+
+        //7) Announcing the update restriction transaction and checking the processed one.
+        MosaicGlobalRestrictionTransaction processedUpdateTransaction = announceAndValidate(
+            type, testAccount, updateTransaction);
+
+        assertTransaction(updateTransaction, processedUpdateTransaction);
+
+        //8) Validating that the endpoints show the new value and type.
+        sleep(1000);
+
+        assertMosaicGlobalRestriction(updateTransaction, get(
+            restrictionRepository.getMosaicGlobalRestriction(mosaicId)));
+
+        assertMosaicGlobalRestriction(updateTransaction, get(
+            restrictionRepository
+                .getMosaicGlobalRestrictions(Collections.singletonList(mosaicId))).get(0));
+
+    }
+
+    private void assertTransaction(
+        MosaicGlobalRestrictionTransaction expectedTransaction,
+        MosaicGlobalRestrictionTransaction processedTransaction) {
+
+        Assertions.assertEquals(expectedTransaction.getMosaicId().getId(),
+            processedTransaction.getMosaicId().getId());
+
+        Assertions.assertEquals(expectedTransaction.getReferenceMosaicId(),
+            processedTransaction.getReferenceMosaicId());
+
+        Assertions.assertEquals(expectedTransaction.getNewRestrictionType(),
+            processedTransaction.getNewRestrictionType());
+
+        Assertions.assertEquals(expectedTransaction.getPreviousRestrictionType(),
+            processedTransaction.getPreviousRestrictionType());
+
+        Assertions.assertEquals(expectedTransaction.getNewRestrictionValue(),
+            processedTransaction.getNewRestrictionValue());
+
+        Assertions.assertEquals(expectedTransaction.getPreviousRestrictionValue(),
+            processedTransaction.getPreviousRestrictionValue());
+
+        Assertions.assertEquals(expectedTransaction.getRestrictionKey(),
+            processedTransaction.getRestrictionKey());
+    }
+
+    private void assertMosaicGlobalRestriction(
+        MosaicGlobalRestrictionTransaction mosaicGlobalRestrictionTransaction,
+        MosaicGlobalRestriction mosaicGlobalRestriction) {
+
+        BigInteger restrictionKey = mosaicGlobalRestrictionTransaction.getRestrictionKey();
+        BigInteger newRestrictionValue = mosaicGlobalRestrictionTransaction
+            .getNewRestrictionValue();
+
+        Assertions.assertEquals(restrictionKey,
+            mosaicGlobalRestrictionTransaction.getRestrictionKey());
+
+        Assertions.assertEquals(1, mosaicGlobalRestriction.getRestrictions().size());
+
+        Assertions.assertEquals(Collections.singleton(restrictionKey),
+            mosaicGlobalRestriction.getRestrictions().keySet());
+
+        Assertions.assertEquals(newRestrictionValue,
+            mosaicGlobalRestriction.getRestrictions().get(restrictionKey)
+                .getRestrictionValue());
+
+        Assertions.assertEquals(mosaicGlobalRestrictionTransaction.getNewRestrictionType(),
+            mosaicGlobalRestriction.getRestrictions().get(restrictionKey)
+                .getRestrictionType());
+
+        Assertions.assertEquals(new MosaicId(BigInteger.ZERO),
+            mosaicGlobalRestriction.getRestrictions().get(restrictionKey)
+                .getReferenceMosaicId());
+    }
+
+    @ParameterizedTest
+    @EnumSource(RepositoryType.class)
+    void createUpdateMosaicAddressRestrictionTransactionFactory(RepositoryType type)
+        throws InterruptedException {
+
+        //1) Create a new mosaic
+        MosaicId mosaicId = createMosaic(testAccount, type, null, null);
+
+        //2) Create a restriction on the mosaic
+
+        MosaicRestrictionTransactionService restrictionService = getMosaicRestrictionTransactionService(
+            type);
+
+        BigInteger originalValue = BigInteger.valueOf(20);
+        MosaicRestrictionType originalRestrictionType = MosaicRestrictionType.GE;
+        MosaicGlobalRestrictionTransaction createTransaction =
+            get(restrictionService.createMosaicGlobalRestrictionTransactionFactory(
+                mosaicId,
+                restrictionKey,
+                originalValue,
+                originalRestrictionType
+            )).maxFee(this.maxFee).build();
+
+        //3) Announce the create restriction transaction
+        MosaicGlobalRestrictionTransaction processedCreateTransaction = announceAndValidate(
+            type, testAccount, createTransaction);
+        //4) Validate that the received processedCreateTransaction and the create transaction are the same
+        assertTransaction(createTransaction, processedCreateTransaction);
+
+        //5) Validate the data from the endpoints
+        sleep(1000);
+
+        RestrictionMosaicRepository restrictionRepository = getRepositoryFactory(type)
+            .createRestrictionMosaicRepository();
+
+        assertMosaicGlobalRestriction(createTransaction, get(
+            restrictionRepository.getMosaicGlobalRestriction(mosaicId)));
+
+        assertMosaicGlobalRestriction(createTransaction, get(
+            restrictionRepository
+                .getMosaicGlobalRestrictions(Collections.singletonList(mosaicId))).get(0));
+
+        // 6) Create the restriction by sending a new transaction
+        MosaicAddressRestrictionTransaction createAddressTransaction =
+            get(restrictionService.createMosaicAddressRestrictionTransactionFactory(
+                mosaicId,
+                restrictionKey,
+                testAccount.getAddress(),
+                BigInteger.valueOf(40)
+            )).maxFee(this.maxFee).build();
+
+        announceAndValidate(
+            type, testAccount, createAddressTransaction);
+
+        sleep(2000);
+
+        //7) Announcing the update restriction transaction and checking the processed one.
+        MosaicAddressRestrictionTransaction updateAddressTransaction =
+            get(restrictionService.createMosaicAddressRestrictionTransactionFactory(
+                mosaicId,
+                restrictionKey,
+                testAccount.getAddress(),
+                BigInteger.valueOf(50)
+            )).maxFee(this.maxFee).build();
+
+        MosaicAddressRestrictionTransaction finalTransaction = announceAndValidate(
+            type, testAccount, updateAddressTransaction);
+
+        Assertions.assertEquals(BigInteger.valueOf(50), finalTransaction.getNewRestrictionValue());
+        Assertions
+            .assertEquals(BigInteger.valueOf(40), finalTransaction.getPreviousRestrictionValue());
+
+    }
+
+
+    @ParameterizedTest
+    @EnumSource(RepositoryType.class)
+    void createUpdateMosaicAddressRestrictionTransactionFactoryUsingAlias(RepositoryType type)
+        throws InterruptedException {
+
+        //1) Create mosaic and alias
+        String masaicAliasName = "createUpdateMosaicAddressRestrictionTransactionFactoryUsingAlias"
+            .toLowerCase();
+        NamespaceId mosaicAlias = NamespaceId.createFromName(masaicAliasName);
+        MosaicId mosaicId = createMosaic(testAccount, type, null, masaicAliasName);
+
+        //2) Create a restriction on the mosaic
+
+        MosaicRestrictionTransactionService restrictionService = getMosaicRestrictionTransactionService(
+            type);
+
+        BigInteger originalValue = BigInteger.valueOf(20);
+        MosaicRestrictionType originalRestrictionType = MosaicRestrictionType.GE;
+        MosaicGlobalRestrictionTransaction createTransaction =
+            get(restrictionService.createMosaicGlobalRestrictionTransactionFactory(
+                mosaicAlias,
+                restrictionKey,
+                originalValue,
+                originalRestrictionType
+            )).maxFee(this.maxFee).build();
+
+        //3) Announce the create restriction transaction
+        MosaicGlobalRestrictionTransaction processedCreateTransaction = announceAndValidate(
+            type, testAccount, createTransaction);
+        //4) Validate that the received processedCreateTransaction and the create transaction are the same
+        assertTransaction(createTransaction, processedCreateTransaction);
+
+        //5) Validate the data from the endpoints
+        sleep(1000);
+
+        RestrictionMosaicRepository restrictionRepository = getRepositoryFactory(type)
+            .createRestrictionMosaicRepository();
+
+        assertMosaicGlobalRestriction(createTransaction, get(
+            restrictionRepository.getMosaicGlobalRestriction(mosaicId)));
+
+        assertMosaicGlobalRestriction(createTransaction, get(
+            restrictionRepository
+                .getMosaicGlobalRestrictions(Collections.singletonList(mosaicId))).get(0));
+
+        // 6) Create the restriction by sending a new transaction
+        MosaicAddressRestrictionTransaction createAddressTransaction =
+            get(restrictionService.createMosaicAddressRestrictionTransactionFactory(
+                mosaicAlias,
+                restrictionKey,
+                testAccount.getAddress(),
+                BigInteger.valueOf(40)
+            )).maxFee(this.maxFee).build();
+
+        announceAndValidate(
+            type, testAccount, createAddressTransaction);
+
+        sleep(2000);
+
+        //7) Announcing the update restriction transaction and checking the processed one.
+        MosaicAddressRestrictionTransaction updateAddressTransaction =
+            get(restrictionService.createMosaicAddressRestrictionTransactionFactory(
+                mosaicAlias,
+                restrictionKey,
+                testAccount.getAddress(),
+                BigInteger.valueOf(50)
+            )).maxFee(this.maxFee).build();
+
+        MosaicAddressRestrictionTransaction finalTransaction = announceAndValidate(
+            type, testAccount, updateAddressTransaction);
+
+        Assertions.assertEquals(BigInteger.valueOf(50), finalTransaction.getNewRestrictionValue());
+        Assertions
+            .assertEquals(BigInteger.valueOf(40), finalTransaction.getPreviousRestrictionValue());
+
+    }
+
+}

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/NamespaceMetadataIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/NamespaceMetadataIntegrationTest.java
@@ -90,8 +90,6 @@ public class NamespaceMetadataIntegrationTest extends BaseIntegrationTest {
 
         System.out.println("Metadata '" + message + "' stored!");
 
-        sleep(1000);
-
         List<Metadata> metadata = get(getRepositoryFactory(type).createMetadataRepository()
             .getNamespaceMetadata(targetNamespaceId,
                 Optional.empty()));

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/NamespaceMetadataServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/NamespaceMetadataServiceIntegrationTest.java
@@ -66,8 +66,6 @@ class NamespaceMetadataServiceIntegrationTest extends BaseIntegrationTest {
 
         announceAggregateAndValidate(type, originalTransaction, signerAccount);
 
-        sleep(2000);
-
         assertMetadata(targetNamespaceId, key, originalMessage, metadataRepository);
 
         NamespaceMetadataTransaction updateTransaction = get(service
@@ -77,8 +75,6 @@ class NamespaceMetadataServiceIntegrationTest extends BaseIntegrationTest {
             .maxFee(this.maxFee).build();
 
         announceAggregateAndValidate(type, updateTransaction, signerAccount);
-
-        sleep(2000);
 
         assertMetadata(targetNamespaceId, key, newMessage, metadataRepository);
 

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/NamespaceMetadataServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/NamespaceMetadataServiceIntegrationTest.java
@@ -59,7 +59,7 @@ class NamespaceMetadataServiceIntegrationTest extends BaseIntegrationTest {
             repositoryFactory);
 
         NamespaceMetadataTransaction originalTransaction = get(service
-            .createNamespaceMetadataTransactionFactory(getNetworkType(),
+            .createNamespaceMetadataTransactionFactory(
                 targetAccount.getPublicAccount(), key, originalMessage,
                 signerAccount.getPublicAccount().getPublicKey(), targetNamespaceId))
             .maxFee(this.maxFee).build();
@@ -71,7 +71,7 @@ class NamespaceMetadataServiceIntegrationTest extends BaseIntegrationTest {
         assertMetadata(targetNamespaceId, key, originalMessage, metadataRepository);
 
         NamespaceMetadataTransaction updateTransaction = get(service
-            .createNamespaceMetadataTransactionFactory(getNetworkType(),
+            .createNamespaceMetadataTransactionFactory(
                 targetAccount.getPublicAccount(), key, newMessage,
                 signerAccount.getPublicAccount().getPublicKey(), targetNamespaceId))
             .maxFee(this.maxFee).build();

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/TransactionRepositoryIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/TransactionRepositoryIntegrationTest.java
@@ -87,6 +87,8 @@ public class TransactionRepositoryIntegrationTest extends BaseIntegrationTest {
         TransactionStatus transactionStatus =
             get(getTransactionRepository(type).getTransactionStatus(transactionHash));
 
+        System.out.println(transactionHash);
+        System.out.println(transactionStatus.getStatus());
         assertEquals(transactionHash, transactionStatus.getHash());
     }
 

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/TransactionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/TransactionServiceIntegrationTest.java
@@ -50,7 +50,6 @@ public class TransactionServiceIntegrationTest extends BaseIntegrationTest {
         throws InterruptedException {
         String hash = transferUsingAliases(config().getNemesisAccount(), type, "cat.currency",
             "testaccount2", BigInteger.TEN).getTransactionInfo().get().getHash().get();
-        sleep(2000);
 
         List<Transaction> transactions = get(
             getTransactionService(type).resolveAliases(Collections.singletonList(hash)));
@@ -82,8 +81,6 @@ public class TransactionServiceIntegrationTest extends BaseIntegrationTest {
             config().getNemesisAccount(), type, mosaicAlias,
             "testaccount2", BigInteger.ONE).getTransactionInfo().get().getHash().get();
 
-        sleep(2000);
-
         List<Transaction> transactions = get(
             getTransactionService(type)
                 .resolveAliases(Arrays.asList(transferTransactionHash)));
@@ -105,8 +102,6 @@ public class TransactionServiceIntegrationTest extends BaseIntegrationTest {
         String aggregateTransactionHash = transferUsingAliasesAggregate(
             config().getNemesisAccount(), type, mosaicAlias,
             "testaccount2", BigInteger.ONE).getTransactionInfo().get().getHash().get();
-
-        sleep(2000);
 
         List<Transaction> transactions = get(
             getTransactionService(type)
@@ -158,7 +153,6 @@ public class TransactionServiceIntegrationTest extends BaseIntegrationTest {
 
             mosaicId = createMosaic(account, type, BigInteger.valueOf(100000), mosaicAlias);
 
-            sleep(2000);
         }
         return mosaicId;
     }

--- a/integration-tests/src/test/java/io/nem/sdk/infrastructure/TransferTransactionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/sdk/infrastructure/TransferTransactionIntegrationTest.java
@@ -108,7 +108,6 @@ public class TransferTransactionIntegrationTest extends BaseIntegrationTest {
         assertTransferTransactions(transferTransaction, processed);
 
         assertEncryptedMessageTransaction(message, senderKeyPair, recipientKeyPair, processed);
-        sleep(1000);
 
         TransferTransaction restTransaction = (TransferTransaction) get(
             getRepositoryFactory(type).createTransactionRepository()
@@ -162,7 +161,6 @@ public class TransferTransactionIntegrationTest extends BaseIntegrationTest {
         TransferTransaction processed = announceAndValidate(type, account, transferTransaction);
 
         assertPersistentDelegationTransaction(senderKeyPair, recipientKeyPair, processed);
-        sleep(1000);
 
         TransferTransaction restTransaction = (TransferTransaction) get(
             getRepositoryFactory(type).createTransactionRepository()

--- a/sdk-core/src/main/java/io/nem/sdk/api/AliasService.java
+++ b/sdk-core/src/main/java/io/nem/sdk/api/AliasService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nem.sdk.api;
+
+import io.nem.sdk.model.account.Address;
+import io.nem.sdk.model.account.UnresolvedAddress;
+import io.nem.sdk.model.mosaic.MosaicId;
+import io.nem.sdk.model.mosaic.UnresolvedMosaicId;
+import io.reactivex.Observable;
+
+/**
+ * Service used to resolve aliases.
+ */
+public interface AliasService {
+
+    /**
+     * This method returns the resolved {@link MosaicId} from the {@link UnresolvedMosaicId}. If the
+     * {@link UnresolvedMosaicId} is an alias, it finds the real {@link MosaicId} by using the
+     * namespace endpoints.
+     *
+     * @param unresolvedMosaicId the unresolvedMosaicId
+     * @return {@link MosaicId} from the namespace endpoint if it's an alias or Mosaic Id if it's an
+     * mosaic id.
+     */
+    Observable<MosaicId> resolveMosaicId(UnresolvedMosaicId unresolvedMosaicId);
+
+    /**
+     * This method returns the resolved {@link Address} from the {@link UnresolvedAddress}. If the
+     * {@link UnresolvedAddress} is an alias, it finds the real {@link Address} by using the
+     * namespace endpoints.
+     *
+     * @param unresolvedAddress the unresolvedAddress
+     * @return {@link Address} from the namespace endpoint if it's an alias or Address if it's an
+     * address.
+     */
+    Observable<Address> resolveAddress(UnresolvedAddress unresolvedAddress);
+}

--- a/sdk-core/src/main/java/io/nem/sdk/api/MetadataTransactionService.java
+++ b/sdk-core/src/main/java/io/nem/sdk/api/MetadataTransactionService.java
@@ -2,8 +2,7 @@ package io.nem.sdk.api;
 
 import io.nem.core.crypto.PublicKey;
 import io.nem.sdk.model.account.PublicAccount;
-import io.nem.sdk.model.blockchain.NetworkType;
-import io.nem.sdk.model.mosaic.MosaicId;
+import io.nem.sdk.model.mosaic.UnresolvedMosaicId;
 import io.nem.sdk.model.namespace.NamespaceId;
 import io.nem.sdk.model.transaction.AccountMetadataTransactionFactory;
 import io.nem.sdk.model.transaction.MosaicMetadataTransactionFactory;
@@ -21,7 +20,6 @@ public interface MetadataTransactionService {
     /**
      * Create an Account Metadata Transaction that knows how to set or update a value.
      *
-     * @param networkType the network type
      * @param targetPublicAccount the target public account
      * @param key the key of the metadata
      * @param value the value of the metadata.
@@ -30,7 +28,6 @@ public interface MetadataTransactionService {
      * announced.
      */
     Observable<AccountMetadataTransactionFactory> createAccountMetadataTransactionFactory(
-        NetworkType networkType,
         PublicAccount targetPublicAccount,
         BigInteger key,
         String value,
@@ -39,7 +36,6 @@ public interface MetadataTransactionService {
     /**
      * Create an Mosaic Metadata Transaction that knows how to set or update a value.
      *
-     * @param networkType the network type
      * @param targetPublicAccount the target public account
      * @param key the key of the metadata
      * @param value the value of the metadata.
@@ -49,17 +45,15 @@ public interface MetadataTransactionService {
      * announced.
      */
     Observable<MosaicMetadataTransactionFactory> createMosaicMetadataTransactionFactory(
-        NetworkType networkType,
         PublicAccount targetPublicAccount,
         BigInteger key,
         String value,
         PublicKey senderPublicKey,
-        MosaicId targetId);
+        UnresolvedMosaicId targetId);
 
     /**
      * Create an Namespace Metadata Transaction that knows how to set or update a value.
      *
-     * @param networkType the network type
      * @param targetPublicAccount the target public account
      * @param key the key of the metadata
      * @param value the value of the metadata.
@@ -69,7 +63,6 @@ public interface MetadataTransactionService {
      * announced.
      */
     Observable<NamespaceMetadataTransactionFactory> createNamespaceMetadataTransactionFactory(
-        NetworkType networkType,
         PublicAccount targetPublicAccount,
         BigInteger key,
         String value,

--- a/sdk-core/src/main/java/io/nem/sdk/api/MosaicRestrictionTransactionService.java
+++ b/sdk-core/src/main/java/io/nem/sdk/api/MosaicRestrictionTransactionService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nem.sdk.api;
+
+import io.nem.sdk.model.account.UnresolvedAddress;
+import io.nem.sdk.model.mosaic.UnresolvedMosaicId;
+import io.nem.sdk.model.transaction.MosaicAddressRestrictionTransactionFactory;
+import io.nem.sdk.model.transaction.MosaicGlobalRestrictionTransactionFactory;
+import io.nem.sdk.model.transaction.MosaicRestrictionType;
+import io.reactivex.Observable;
+import java.math.BigInteger;
+
+/**
+ * Service that helps clients setting up and updating mosaic restrictions.
+ */
+public interface MosaicRestrictionTransactionService {
+
+    /**
+     * Create a {@link MosaicGlobalRestrictionTransactionFactory} object without previous
+     * restriction data
+     *
+     * @param mosaicId MosaicId
+     * @param restrictionKey Restriction key
+     * @param restrictionValue New restriction value
+     * @param restrictionType New restriction type
+     * @return MosaicGlobalRestrictionTransactionFactory of the transaction ready to be announced.
+     */
+    Observable<MosaicGlobalRestrictionTransactionFactory> createMosaicGlobalRestrictionTransactionFactory(
+        UnresolvedMosaicId mosaicId,
+        BigInteger restrictionKey,
+        BigInteger restrictionValue,
+        MosaicRestrictionType restrictionType);
+
+
+    /**
+     * Create a {@link MosaicAddressRestrictionTransactionFactory} object without previous
+     * restriction data
+     *
+     * @param mosaicId MosaicId
+     * @param restrictionKey Restriction key
+     * @param targetAddress Target address
+     * @param restrictionValue New restriction value
+     * @return {@link MosaicAddressRestrictionTransactionFactory} object without previous
+     * restriction data
+     */
+    Observable<MosaicAddressRestrictionTransactionFactory> createMosaicAddressRestrictionTransactionFactory(
+        UnresolvedMosaicId mosaicId,
+        BigInteger restrictionKey,
+        UnresolvedAddress targetAddress,
+        BigInteger restrictionValue);
+}

--- a/sdk-core/src/main/java/io/nem/sdk/api/MosaicRestrictionTransactionService.java
+++ b/sdk-core/src/main/java/io/nem/sdk/api/MosaicRestrictionTransactionService.java
@@ -30,10 +30,19 @@ import java.math.BigInteger;
 public interface MosaicRestrictionTransactionService {
 
     /**
-     * Create a {@link MosaicGlobalRestrictionTransactionFactory} object without previous
-     * restriction data
+     * Create a {@link MosaicGlobalRestrictionTransactionFactory} object that can be used to create
+     * or update a mosaic global restriction.
      *
-     * @param mosaicId MosaicId
+     * This service checks the current global restriction value using rest and set the corresponding
+     * previousRestrictionType and previousRestrictionValue so an update can be performed.
+     *
+     *
+     * When using aliases, the service will resolve them in order to query the mosaic restriction
+     * rest endpoint. This could add some overhead. If you know the real mosaic id, it's recommended
+     * to use it.
+     *
+     * @param mosaicId the mosaic id or an alias. If an alias is sent, the service will resolve it
+     * in order to retrieve the current global restriction value.
      * @param restrictionKey Restriction key
      * @param restrictionValue New restriction value
      * @param restrictionType New restriction type
@@ -47,12 +56,21 @@ public interface MosaicRestrictionTransactionService {
 
 
     /**
-     * Create a {@link MosaicAddressRestrictionTransactionFactory} object without previous
-     * restriction data
+     * Create a {@link MosaicAddressRestrictionTransactionFactory} object that can be used to create
+     * or update a mosaic address restriction.
      *
-     * @param mosaicId MosaicId
+     * This service checks the current address restriction value using rest and set the
+     * corresponding previousRestrictionValue so an update can be performed.
+     *
+     * When using aliases, the service will resolve them in order to query the mosaic restriction
+     * rest endpoint. This could add some overhead. If you know the real mosaic id and target
+     * address, it's recommended to use them.
+     *
+     * @param mosaicId the mosaic id or an alias. If an alias is sent, the service will resolve it *
+     * in order to retrieve the current mosaic address restriction value.
      * @param restrictionKey Restriction key
-     * @param targetAddress Target address
+     * @param targetAddress the target address or an alias. If an alias is sent, the service will
+     * resolve it in order to retrieve the current mosaic address restriction value.
      * @param restrictionValue New restriction value
      * @return {@link MosaicAddressRestrictionTransactionFactory} object without previous
      * restriction data

--- a/sdk-core/src/main/java/io/nem/sdk/api/RepositoryFactory.java
+++ b/sdk-core/src/main/java/io/nem/sdk/api/RepositoryFactory.java
@@ -30,7 +30,7 @@ public interface RepositoryFactory extends Closeable {
 
     /**
      * @return the network type of the network. This method is cached, the server is only called the
-     * first time.
+     * first time if necessary.
      */
     Observable<NetworkType> getNetworkType();
 

--- a/sdk-core/src/main/java/io/nem/sdk/infrastructure/AliasServiceImpl.java
+++ b/sdk-core/src/main/java/io/nem/sdk/infrastructure/AliasServiceImpl.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nem.sdk.infrastructure;
+
+import io.nem.sdk.api.AliasService;
+import io.nem.sdk.api.NamespaceRepository;
+import io.nem.sdk.api.RepositoryFactory;
+import io.nem.sdk.model.account.Address;
+import io.nem.sdk.model.account.UnresolvedAddress;
+import io.nem.sdk.model.mosaic.MosaicId;
+import io.nem.sdk.model.mosaic.UnresolvedMosaicId;
+import io.nem.sdk.model.namespace.AliasType;
+import io.nem.sdk.model.namespace.NamespaceId;
+import io.reactivex.Observable;
+import org.apache.commons.lang3.Validate;
+
+/**
+ * Implementation of the alias service.
+ */
+public class AliasServiceImpl implements AliasService {
+
+    private final NamespaceRepository namespaceRepository;
+
+    /**
+     * Constructor
+     *
+     * @param repositoryFactory repository factory.
+     */
+    public AliasServiceImpl(RepositoryFactory repositoryFactory) {
+        this.namespaceRepository = repositoryFactory.createNamespaceRepository();
+    }
+
+    @Override
+    public Observable<MosaicId> resolveMosaicId(UnresolvedMosaicId unresolvedMosaicId) {
+        if (unresolvedMosaicId.isAlias()) {
+            NamespaceId alias = (NamespaceId) unresolvedMosaicId;
+            return namespaceRepository.getNamespace(alias)
+                .map(namespaceInfo -> {
+                    Validate.isTrue(namespaceInfo.getAlias().getType() == AliasType.MOSAIC,
+                        "Alias is not Mosaic");
+                    return (MosaicId) namespaceInfo.getAlias().getAliasValue();
+                })
+                .onErrorResumeNext(e -> {
+                    return Observable.error(new IllegalArgumentException(
+                        "MosaicId could not be resolved from alias " + alias.getIdAsHex(), e));
+                });
+        } else {
+            return Observable.just((MosaicId) unresolvedMosaicId);
+        }
+
+    }
+
+    @Override
+    public Observable<Address> resolveAddress(UnresolvedAddress unresolvedAddress) {
+        if (unresolvedAddress.isAlias()) {
+            NamespaceId alias = (NamespaceId) unresolvedAddress;
+            return namespaceRepository.getNamespace(alias)
+                .map(namespaceInfo -> {
+                    Validate.isTrue(namespaceInfo.getAlias().getType() == AliasType.ADDRESS,
+                        "Alias is not address");
+                    return (Address) namespaceInfo.getAlias().getAliasValue();
+                })
+                .onErrorResumeNext(e -> {
+                    return Observable.error(new IllegalArgumentException(
+                        "Address could not be resolved from alias " + alias.getIdAsHex(), e));
+                });
+        } else {
+            return Observable.just((Address) unresolvedAddress);
+        }
+
+    }
+
+}

--- a/sdk-core/src/main/java/io/nem/sdk/infrastructure/MetadataTransactionServiceImpl.java
+++ b/sdk-core/src/main/java/io/nem/sdk/infrastructure/MetadataTransactionServiceImpl.java
@@ -56,11 +56,11 @@ public class MetadataTransactionServiceImpl implements MetadataTransactionServic
     @Override
     public Observable<MosaicMetadataTransactionFactory> createMosaicMetadataTransactionFactory(
         PublicAccount targetPublicAccount, BigInteger key, String value,
-        PublicKey senderPublicKey, UnresolvedMosaicId unresolvedMosaicId) {
+        PublicKey senderPublicKey, UnresolvedMosaicId unresolvedTargetId) {
 
-        return aliasService.resolveMosaicId(unresolvedMosaicId).flatMap(targetId -> {
+        return aliasService.resolveMosaicId(unresolvedTargetId).flatMap(targetId -> {
             BiFunction<String, NetworkType, MosaicMetadataTransactionFactory> factory = (newValue, networkType) -> MosaicMetadataTransactionFactory
-                .create(networkType, targetPublicAccount, targetId, key, newValue);
+                .create(networkType, targetPublicAccount, unresolvedTargetId, key, newValue);
             return processMetadata(metadataRepository
                     .getMosaicMetadataByKeyAndSender(targetId, key, senderPublicKey.toHex()), factory,
                 value);

--- a/sdk-core/src/main/java/io/nem/sdk/infrastructure/MetadataTransactionServiceImpl.java
+++ b/sdk-core/src/main/java/io/nem/sdk/infrastructure/MetadataTransactionServiceImpl.java
@@ -3,6 +3,7 @@ package io.nem.sdk.infrastructure;
 import io.nem.core.crypto.PublicKey;
 import io.nem.core.utils.ConvertUtils;
 import io.nem.core.utils.StringEncoder;
+import io.nem.sdk.api.AliasService;
 import io.nem.sdk.api.MetadataRepository;
 import io.nem.sdk.api.MetadataTransactionService;
 import io.nem.sdk.api.RepositoryCallException;
@@ -11,7 +12,7 @@ import io.nem.sdk.model.account.Address;
 import io.nem.sdk.model.account.PublicAccount;
 import io.nem.sdk.model.blockchain.NetworkType;
 import io.nem.sdk.model.metadata.Metadata;
-import io.nem.sdk.model.mosaic.MosaicId;
+import io.nem.sdk.model.mosaic.UnresolvedMosaicId;
 import io.nem.sdk.model.namespace.NamespaceId;
 import io.nem.sdk.model.transaction.AccountMetadataTransactionFactory;
 import io.nem.sdk.model.transaction.MetadataTransactionFactory;
@@ -19,7 +20,7 @@ import io.nem.sdk.model.transaction.MosaicMetadataTransactionFactory;
 import io.nem.sdk.model.transaction.NamespaceMetadataTransactionFactory;
 import io.reactivex.Observable;
 import java.math.BigInteger;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 /**
  * Implementation of {@link MetadataTransactionService}
@@ -30,17 +31,22 @@ public class MetadataTransactionServiceImpl implements MetadataTransactionServic
 
     private final MetadataRepository metadataRepository;
 
+    private final Observable<NetworkType> networkTypeObservable;
+
+    private final AliasService aliasService;
+
     public MetadataTransactionServiceImpl(RepositoryFactory factory) {
         this.metadataRepository = factory.createMetadataRepository();
+        this.networkTypeObservable = factory.getNetworkType();
+        this.aliasService = new AliasServiceImpl(factory);
     }
 
     @Override
     public Observable<AccountMetadataTransactionFactory> createAccountMetadataTransactionFactory(
-        NetworkType networkType,
         PublicAccount targetPublicAccount, BigInteger key, String value,
         PublicKey senderPublicKey) {
         Address address = targetPublicAccount.getAddress();
-        Function<String, AccountMetadataTransactionFactory> factory = newValue -> AccountMetadataTransactionFactory
+        BiFunction<String, NetworkType, AccountMetadataTransactionFactory> factory = (newValue, networkType) -> AccountMetadataTransactionFactory
             .create(networkType, targetPublicAccount, key, newValue);
         return processMetadata(metadataRepository
                 .getAccountMetadataByKeyAndSender(address, key, senderPublicKey.toHex()), factory,
@@ -49,25 +55,24 @@ public class MetadataTransactionServiceImpl implements MetadataTransactionServic
 
     @Override
     public Observable<MosaicMetadataTransactionFactory> createMosaicMetadataTransactionFactory(
-        NetworkType networkType,
         PublicAccount targetPublicAccount, BigInteger key, String value,
-        PublicKey senderPublicKey,
-        MosaicId targetId) {
+        PublicKey senderPublicKey, UnresolvedMosaicId unresolvedMosaicId) {
 
-        Function<String, MosaicMetadataTransactionFactory> factory = newValue -> MosaicMetadataTransactionFactory
-            .create(networkType, targetPublicAccount, targetId, key, newValue);
-        return processMetadata(metadataRepository
-                .getMosaicMetadataByKeyAndSender(targetId, key, senderPublicKey.toHex()), factory,
-            value);
+        return aliasService.resolveMosaicId(unresolvedMosaicId).flatMap(targetId -> {
+            BiFunction<String, NetworkType, MosaicMetadataTransactionFactory> factory = (newValue, networkType) -> MosaicMetadataTransactionFactory
+                .create(networkType, targetPublicAccount, targetId, key, newValue);
+            return processMetadata(metadataRepository
+                    .getMosaicMetadataByKeyAndSender(targetId, key, senderPublicKey.toHex()), factory,
+                value);
+        });
     }
 
     @Override
     public Observable<NamespaceMetadataTransactionFactory> createNamespaceMetadataTransactionFactory(
-        NetworkType networkType,
         PublicAccount targetPublicAccount, BigInteger key, String value,
         PublicKey senderPublicKey,
         NamespaceId targetId) {
-        Function<String, NamespaceMetadataTransactionFactory> factory = newValue -> NamespaceMetadataTransactionFactory
+        BiFunction<String, NetworkType, NamespaceMetadataTransactionFactory> factory = (newValue, networkType) -> NamespaceMetadataTransactionFactory
             .create(networkType, targetPublicAccount, targetId, key, newValue);
         return processMetadata(metadataRepository
                 .getNamespaceMetadataByKeyAndSender(targetId, key, senderPublicKey.toHex()), factory,
@@ -87,23 +92,24 @@ public class MetadataTransactionServiceImpl implements MetadataTransactionServic
      */
     private <T extends MetadataTransactionFactory> Observable<T> processMetadata(
         Observable<Metadata> metadataObservable,
-        Function<String, T> transactionFactory, String newValue) {
-        return metadataObservable.map(metadata -> {
+        BiFunction<String, NetworkType, T> transactionFactory, String newValue) {
+        return networkTypeObservable.flatMap(networkType -> metadataObservable.map(metadata -> {
             byte[] currentValueBytes = StringEncoder
                 .getBytes(metadata.getMetadataEntry().getValue());
             byte[] newValueBytes = StringEncoder.getBytes(newValue);
             String xorValue = StringEncoder
                 .getString(ConvertUtils.xor(currentValueBytes, newValueBytes));
-            T factory = transactionFactory.apply(xorValue);
+            T factory = transactionFactory.apply(xorValue, networkType);
             factory.valueSizeDelta(newValueBytes.length - currentValueBytes.length);
             return factory;
         }).onErrorResumeNext(exception -> {
             if (exception instanceof RepositoryCallException
                 && ((RepositoryCallException) exception).getStatusCode() == 404) {
-                return Observable.just(transactionFactory.apply(newValue));
+                return Observable.just(transactionFactory.apply(newValue, networkType));
             } else {
                 return Observable.error(exception);
             }
-        });
+        }));
+
     }
 }

--- a/sdk-core/src/main/java/io/nem/sdk/infrastructure/MosaicRestrictionTransactionServiceImpl.java
+++ b/sdk-core/src/main/java/io/nem/sdk/infrastructure/MosaicRestrictionTransactionServiceImpl.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nem.sdk.infrastructure;
+
+import io.nem.sdk.api.AliasService;
+import io.nem.sdk.api.MosaicRestrictionTransactionService;
+import io.nem.sdk.api.RepositoryCallException;
+import io.nem.sdk.api.RepositoryFactory;
+import io.nem.sdk.api.RestrictionMosaicRepository;
+import io.nem.sdk.model.account.Address;
+import io.nem.sdk.model.account.UnresolvedAddress;
+import io.nem.sdk.model.blockchain.NetworkType;
+import io.nem.sdk.model.mosaic.MosaicId;
+import io.nem.sdk.model.mosaic.UnresolvedMosaicId;
+import io.nem.sdk.model.restriction.MosaicGlobalRestrictionItem;
+import io.nem.sdk.model.transaction.MosaicAddressRestrictionTransactionFactory;
+import io.nem.sdk.model.transaction.MosaicGlobalRestrictionTransactionFactory;
+import io.nem.sdk.model.transaction.MosaicRestrictionType;
+import io.reactivex.Observable;
+import java.math.BigInteger;
+import java.util.Optional;
+
+/**
+ * Implementation of {@link MosaicRestrictionTransactionService}.
+ */
+public class MosaicRestrictionTransactionServiceImpl implements
+    MosaicRestrictionTransactionService {
+
+    /**
+     * The network type so user is not required to provide it each time.
+     */
+    private final Observable<NetworkType> networkTypeObservable;
+
+    /**
+     * The repository used to retrieve the old mosaic restriction values.
+     */
+    private final RestrictionMosaicRepository repository;
+    /**
+     * The repository used to resolve aliases.
+     */
+    private final AliasService aliasService;
+
+    /**
+     * The constructor.
+     *
+     * @param repositoryFactory the repository factory.
+     */
+    public MosaicRestrictionTransactionServiceImpl(
+        RepositoryFactory repositoryFactory) {
+        this.repository = repositoryFactory.createRestrictionMosaicRepository();
+        this.networkTypeObservable = repositoryFactory.getNetworkType();
+        this.aliasService = new AliasServiceImpl(repositoryFactory);
+    }
+
+
+    @Override
+    public Observable<MosaicGlobalRestrictionTransactionFactory> createMosaicGlobalRestrictionTransactionFactory(
+        UnresolvedMosaicId unresolvedMosaicId, BigInteger restrictionKey,
+        BigInteger restrictionValue, MosaicRestrictionType restrictionType) {
+        return aliasService.resolveMosaicId(unresolvedMosaicId).flatMap(mosaicId ->
+            networkTypeObservable.flatMap(networkType ->
+                this.getGlobalRestrictionEntry(mosaicId, restrictionKey).map(optional -> {
+                    MosaicGlobalRestrictionTransactionFactory factory = MosaicGlobalRestrictionTransactionFactory
+                        .create(
+                            networkType,
+                            mosaicId,
+                            restrictionKey,
+                            restrictionValue,
+                            restrictionType);
+
+                    optional.ifPresent(mosaicGlobalRestrictionItem -> {
+                        factory.previousRestrictionValue(
+                            mosaicGlobalRestrictionItem.getRestrictionValue());
+                        factory
+                            .previousRestrictionType(
+                                mosaicGlobalRestrictionItem.getRestrictionType());
+                    });
+                    return factory;
+                })));
+    }
+
+    @Override
+    public Observable<MosaicAddressRestrictionTransactionFactory> createMosaicAddressRestrictionTransactionFactory(
+        UnresolvedMosaicId unresolvedMosaicId, BigInteger restrictionKey,
+        UnresolvedAddress unresolvedTargetAddress, BigInteger restrictionValue) {
+
+        return Observable
+            .combineLatest(networkTypeObservable, aliasService.resolveMosaicId(unresolvedMosaicId),
+                aliasService.resolveAddress(unresolvedTargetAddress),
+                (networkType, mosaicId, targetAddress) -> getGlobalRestrictionEntry(
+                    mosaicId,
+                    restrictionKey).flatMap(optional -> {
+                    optional.orElseThrow(() -> new IllegalArgumentException(
+                        "Global restriction is not valid for RestrictionKey: "
+                            + restrictionKey));
+                    return getCurrentMosaicAddressRestrictionValue(
+                        mosaicId, targetAddress,
+                        restrictionKey)
+                        .map(optionalValue -> {
+                            MosaicAddressRestrictionTransactionFactory factory = MosaicAddressRestrictionTransactionFactory
+                                .create(
+                                    networkType,
+                                    mosaicId,
+                                    restrictionKey,
+                                    targetAddress,
+                                    restrictionValue
+                                );
+                            optionalValue.ifPresent(factory::previousRestrictionValue);
+                            return factory;
+                        });
+                })).flatMap(f -> f);
+    }
+
+    /**
+     * Get the mosaic address restriction current value.
+     *
+     * @param mosaicId Mosaic identifier
+     * @param targetAddress the target address.
+     * @param restrictionKey Mosaic global restriction key
+     * @return Observable of BigInteger optional.
+     */
+    private Observable<Optional<BigInteger>> getCurrentMosaicAddressRestrictionValue(
+        MosaicId mosaicId, Address targetAddress, BigInteger restrictionKey) {
+        return emptyOnNotFound(this.repository.getMosaicAddressRestriction(mosaicId, targetAddress)
+            .map(r -> Optional.ofNullable(r.getRestrictions().get(restrictionKey))));
+    }
+
+    /**
+     * Get mosaic global restriction previous value and type
+     *
+     * @param mosaicId Mosaic identifier
+     * @param restrictionKey Mosaic global restriction key
+     * @return Observable of MosaicGlobalRestrictionItem optional.
+     */
+    private Observable<Optional<MosaicGlobalRestrictionItem>> getGlobalRestrictionEntry(
+        MosaicId mosaicId, BigInteger restrictionKey) {
+        return emptyOnNotFound(this.repository.getMosaicGlobalRestriction(mosaicId)
+            .map(r -> Optional.ofNullable(r.getRestrictions().get(restrictionKey))));
+    }
+
+    /**
+     * Utility wrapper that returns an empty object when the rest response returns 404.
+     *
+     * @param call the rest call
+     * @param <T> the type of the response
+     * @return the Observable that returns empty on 404. If there are other rest errors, the
+     * exception is propagated.
+     */
+    private <T> Observable<Optional<T>> emptyOnNotFound(Observable<Optional<T>> call) {
+        return call.onErrorResumeNext(exception -> {
+            if (exception instanceof RepositoryCallException
+                && ((RepositoryCallException) exception).getStatusCode() == 404) {
+                return Observable.just(Optional.empty());
+            } else {
+                return Observable.error(exception);
+            }
+        });
+    }
+
+}

--- a/sdk-core/src/main/java/io/nem/sdk/infrastructure/MosaicRestrictionTransactionServiceImpl.java
+++ b/sdk-core/src/main/java/io/nem/sdk/infrastructure/MosaicRestrictionTransactionServiceImpl.java
@@ -77,7 +77,7 @@ public class MosaicRestrictionTransactionServiceImpl implements
                     MosaicGlobalRestrictionTransactionFactory factory = MosaicGlobalRestrictionTransactionFactory
                         .create(
                             networkType,
-                            mosaicId,
+                            unresolvedMosaicId,
                             restrictionKey,
                             restrictionValue,
                             restrictionType);
@@ -114,9 +114,9 @@ public class MosaicRestrictionTransactionServiceImpl implements
                             MosaicAddressRestrictionTransactionFactory factory = MosaicAddressRestrictionTransactionFactory
                                 .create(
                                     networkType,
-                                    mosaicId,
+                                    unresolvedMosaicId,
                                     restrictionKey,
-                                    targetAddress,
+                                    unresolvedTargetAddress,
                                     restrictionValue
                                 );
                             optionalValue.ifPresent(factory::previousRestrictionValue);

--- a/sdk-core/src/main/java/io/nem/sdk/model/transaction/Deadline.java
+++ b/sdk-core/src/main/java/io/nem/sdk/model/transaction/Deadline.java
@@ -34,7 +34,7 @@ public class Deadline {
     /**
      * Nemesis block timestamp.
      */
-    private static final Instant TIMESTAMP_NEMESIS_BLOCK = Instant.ofEpochSecond(1573426800);
+    private static final Instant TIMESTAMP_NEMESIS_BLOCK = Instant.ofEpochSecond(1573430400);
 
     private final Instant instant;
 

--- a/sdk-core/src/test/java/io/nem/sdk/infrastructure/AliasServiceTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/infrastructure/AliasServiceTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nem.sdk.infrastructure;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.nem.core.utils.ExceptionUtils;
+import io.nem.sdk.api.NamespaceRepository;
+import io.nem.sdk.api.RepositoryFactory;
+import io.nem.sdk.model.account.Account;
+import io.nem.sdk.model.account.Address;
+import io.nem.sdk.model.blockchain.NetworkType;
+import io.nem.sdk.model.mosaic.MosaicId;
+import io.nem.sdk.model.mosaic.MosaicNonce;
+import io.nem.sdk.model.namespace.AddressAlias;
+import io.nem.sdk.model.namespace.MosaicAlias;
+import io.nem.sdk.model.namespace.NamespaceId;
+import io.nem.sdk.model.namespace.NamespaceInfo;
+import io.nem.sdk.model.namespace.NamespaceRegistrationType;
+import io.reactivex.Observable;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests of {@link AliasServiceImpl}
+ */
+public class AliasServiceTest {
+
+
+    private NetworkType networkType = NetworkType.MIJIN_TEST;
+    private AliasServiceImpl service;
+
+    private NamespaceRepository namespaceRepository;
+
+    private Account account1 = Account.generateNewAccount(networkType);
+    private Account account2 = Account.generateNewAccount(networkType);
+    private NamespaceId accountAlias1 = NamespaceId.createFromName("accountAlias1".toLowerCase());
+    private NamespaceId accountAlias2 = NamespaceId.createFromName("accountAlias2".toLowerCase());
+
+
+    private MosaicId mosaicId1 = MosaicId
+        .createFromNonce(MosaicNonce.createRandom(), account1.getPublicAccount());
+    private MosaicId mosaicId2 = MosaicId
+        .createFromNonce(MosaicNonce.createRandom(), account2.getPublicAccount());
+
+    private NamespaceId mosaicAlias1 = NamespaceId.createFromName("mosaicAlias1".toLowerCase());
+    private NamespaceId mosaicAlias2 = NamespaceId.createFromName("mosaicAlias2".toLowerCase());
+
+
+    @BeforeEach
+    void setup() {
+
+        RepositoryFactory factory = mock(RepositoryFactory.class);
+
+        namespaceRepository = mock(NamespaceRepository.class);
+        when(factory.createNamespaceRepository()).thenReturn(namespaceRepository);
+
+        when(factory.getNetworkType()).thenReturn(Observable.just(networkType));
+        service = new AliasServiceImpl(factory);
+
+        when(namespaceRepository.getNamespace(Mockito.any()))
+            .thenReturn(Observable.error(new IllegalStateException("Alias does not exist")));
+
+        when(namespaceRepository.getNamespace(accountAlias1))
+            .thenReturn(Observable.just(createAlias(account1.getAddress())));
+
+        when(namespaceRepository.getNamespace(accountAlias2))
+            .thenReturn(Observable.just(createAlias(account2.getAddress())));
+
+        when(namespaceRepository.getNamespace(mosaicAlias1))
+            .thenReturn(Observable.just(createAlias(mosaicId1)));
+
+        when(namespaceRepository.getNamespace(mosaicAlias2))
+            .thenReturn(Observable.just(createAlias(mosaicId2)));
+
+    }
+
+    private NamespaceInfo createAlias(Address address) {
+
+        return new NamespaceInfo(true, 0, "metadaId", NamespaceRegistrationType.ROOT_NAMESPACE, 1,
+            Collections.emptyList(), null, null, BigInteger.ONE, BigInteger.TEN,
+            new AddressAlias(address));
+    }
+
+    private NamespaceInfo createAlias(MosaicId mosaicId) {
+
+        return new NamespaceInfo(true, 0, "metadaId", NamespaceRegistrationType.ROOT_NAMESPACE, 1,
+            Collections.emptyList(), null, null, BigInteger.ONE, BigInteger.TEN,
+            new MosaicAlias(mosaicId));
+    }
+
+    @Test
+    void resolveAddress() throws ExecutionException, InterruptedException {
+
+        Assertions.assertEquals(account1.getAddress(), service
+            .resolveAddress(accountAlias1).toFuture()
+            .get());
+
+        Assertions.assertEquals(account2.getAddress(), service
+            .resolveAddress(accountAlias2).toFuture()
+            .get());
+
+        Assertions.assertEquals(account1.getAddress(), service
+            .resolveAddress(account1.getAddress()).toFuture()
+            .get());
+
+    }
+
+    @Test
+    void resolveMosaicId() throws ExecutionException, InterruptedException {
+
+        Assertions.assertEquals(mosaicId1, service
+            .resolveMosaicId(mosaicAlias1).toFuture()
+            .get());
+
+        Assertions.assertEquals(mosaicId2, service
+            .resolveMosaicId(mosaicAlias2).toFuture()
+            .get());
+
+        Assertions.assertEquals(mosaicId1, service
+            .resolveMosaicId(mosaicId1).toFuture()
+            .get());
+
+    }
+
+    @Test
+    void resolveAddressWhenDoesNotExist() {
+
+        IllegalArgumentException exception = Assertions
+            .assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.propagate(() ->
+                service
+                    .resolveAddress(NamespaceId.createFromName("invalidaddressaslias")).toFuture()
+                    .get()));
+
+        Assertions.assertEquals("Address could not be resolved from alias 98cc55cca3f13503",
+            exception.getMessage());
+
+    }
+
+    @Test
+    void resolveMosaicIdWhenDoesNotExist() {
+
+        IllegalArgumentException exception = Assertions
+            .assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.propagate(() ->
+                service
+                    .resolveMosaicId(NamespaceId.createFromName("invalidaddressaslias")).toFuture()
+                    .get()));
+
+        Assertions.assertEquals("MosaicId could not be resolved from alias 98cc55cca3f13503",
+            exception.getMessage());
+
+    }
+
+}

--- a/sdk-core/src/test/java/io/nem/sdk/infrastructure/MetadataTransactionServiceTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/infrastructure/MetadataTransactionServiceTest.java
@@ -46,6 +46,7 @@ class MetadataTransactionServiceTest {
         RepositoryFactory factory = Mockito.mock(RepositoryFactory.class);
         metadataRepositoryMock = Mockito.mock(MetadataRepository.class);
         Mockito.when(factory.createMetadataRepository()).thenReturn(metadataRepositoryMock);
+        Mockito.when(factory.getNetworkType()).thenReturn(Observable.just(networkType));
         service = new MetadataTransactionServiceImpl(factory);
     }
 
@@ -76,7 +77,7 @@ class MetadataTransactionServiceTest {
 
         AccountMetadataTransactionFactory result =
             service.createAccountMetadataTransactionFactory(
-                NetworkType.MIJIN_TEST, targetAccount,
+                targetAccount,
                 metadataKey,
                 newValue, senderPublicKey).toFuture().get();
 
@@ -110,7 +111,7 @@ class MetadataTransactionServiceTest {
 
         AccountMetadataTransactionFactory result =
             service.createAccountMetadataTransactionFactory(
-                NetworkType.MIJIN_TEST, targetAccount,
+                targetAccount,
                 metadataKey,
                 newValue, senderPublicKey).toFuture().get();
 
@@ -146,7 +147,7 @@ class MetadataTransactionServiceTest {
         RepositoryCallException exception = Assertions
             .assertThrows(RepositoryCallException.class, () -> ExceptionUtils.propagate(() ->
                 service.createAccountMetadataTransactionFactory(
-                    NetworkType.MIJIN_TEST, targetAccount,
+                    targetAccount,
                     metadataKey,
                     newValue, senderPublicKey).toFuture().get()));
 
@@ -176,7 +177,7 @@ class MetadataTransactionServiceTest {
         IllegalArgumentException exception = Assertions
             .assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.propagate(() ->
                 service.createAccountMetadataTransactionFactory(
-                    NetworkType.MIJIN_TEST, targetAccount,
+                    targetAccount,
                     metadataKey,
                     newValue, senderPublicKey).toFuture().get()));
 
@@ -210,7 +211,7 @@ class MetadataTransactionServiceTest {
 
         MosaicMetadataTransactionFactory result =
             service.createMosaicMetadataTransactionFactory(
-                NetworkType.MIJIN_TEST, targetAccount,
+                targetAccount,
                 metadataKey,
                 newValue, senderPublicKey,
                 mosaicId).toFuture().get();
@@ -246,7 +247,7 @@ class MetadataTransactionServiceTest {
 
         MosaicMetadataTransactionFactory result =
             service.createMosaicMetadataTransactionFactory(
-                NetworkType.MIJIN_TEST, targetAccount,
+                targetAccount,
                 metadataKey,
                 newValue, senderPublicKey,
                 mosaicId).toFuture().get();
@@ -284,7 +285,7 @@ class MetadataTransactionServiceTest {
         RepositoryCallException exception = Assertions
             .assertThrows(RepositoryCallException.class, () -> ExceptionUtils.propagate(() ->
                 service.createMosaicMetadataTransactionFactory(
-                    NetworkType.MIJIN_TEST, targetAccount,
+                    targetAccount,
                     metadataKey,
                     newValue, senderPublicKey, mosaicId).toFuture().get()));
 
@@ -314,7 +315,7 @@ class MetadataTransactionServiceTest {
         IllegalArgumentException exception = Assertions
             .assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.propagate(() ->
                 service.createMosaicMetadataTransactionFactory(
-                    NetworkType.MIJIN_TEST, targetAccount,
+                    targetAccount,
                     metadataKey,
                     newValue, senderPublicKey, mosaicId).toFuture().get()));
 
@@ -348,7 +349,7 @@ class MetadataTransactionServiceTest {
 
         NamespaceMetadataTransactionFactory result =
             service.createNamespaceMetadataTransactionFactory(
-                NetworkType.MIJIN_TEST, targetAccount,
+                targetAccount,
                 metadataKey,
                 newValue, senderPublicKey, namespaceId).toFuture().get();
 
@@ -383,7 +384,7 @@ class MetadataTransactionServiceTest {
 
         NamespaceMetadataTransactionFactory result =
             service.createNamespaceMetadataTransactionFactory(
-                NetworkType.MIJIN_TEST, targetAccount,
+                targetAccount,
                 metadataKey,
                 newValue, senderPublicKey, namespaceId).toFuture().get();
 
@@ -420,7 +421,7 @@ class MetadataTransactionServiceTest {
         RepositoryCallException exception = Assertions
             .assertThrows(RepositoryCallException.class, () -> ExceptionUtils.propagate(() ->
                 service.createNamespaceMetadataTransactionFactory(
-                    NetworkType.MIJIN_TEST, targetAccount,
+                    targetAccount,
                     metadataKey,
                     newValue, senderPublicKey, namespaceId).toFuture().get()));
 
@@ -450,7 +451,7 @@ class MetadataTransactionServiceTest {
         IllegalArgumentException exception = Assertions
             .assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.propagate(() ->
                 service.createNamespaceMetadataTransactionFactory(
-                    NetworkType.MIJIN_TEST, targetAccount,
+                    targetAccount,
                     metadataKey,
                     newValue, senderPublicKey, namespaceId).toFuture().get()));
 

--- a/sdk-core/src/test/java/io/nem/sdk/infrastructure/MosaicRestrictionTransactionServiceTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/infrastructure/MosaicRestrictionTransactionServiceTest.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nem.sdk.infrastructure;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.nem.core.utils.ExceptionUtils;
+import io.nem.sdk.api.NamespaceRepository;
+import io.nem.sdk.api.RepositoryCallException;
+import io.nem.sdk.api.RepositoryFactory;
+import io.nem.sdk.api.RestrictionMosaicRepository;
+import io.nem.sdk.model.account.Account;
+import io.nem.sdk.model.account.Address;
+import io.nem.sdk.model.blockchain.NetworkType;
+import io.nem.sdk.model.mosaic.MosaicId;
+import io.nem.sdk.model.mosaic.MosaicNonce;
+import io.nem.sdk.model.namespace.AddressAlias;
+import io.nem.sdk.model.namespace.MosaicAlias;
+import io.nem.sdk.model.namespace.NamespaceId;
+import io.nem.sdk.model.namespace.NamespaceInfo;
+import io.nem.sdk.model.namespace.NamespaceRegistrationType;
+import io.nem.sdk.model.restriction.MosaicAddressRestriction;
+import io.nem.sdk.model.restriction.MosaicGlobalRestriction;
+import io.nem.sdk.model.restriction.MosaicGlobalRestrictionItem;
+import io.nem.sdk.model.restriction.MosaicRestrictionEntryType;
+import io.nem.sdk.model.transaction.MosaicAddressRestrictionTransaction;
+import io.nem.sdk.model.transaction.MosaicGlobalRestrictionTransaction;
+import io.nem.sdk.model.transaction.MosaicRestrictionType;
+import io.reactivex.Observable;
+import java.math.BigInteger;
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests of {@link MosaicRestrictionTransactionServiceImpl}
+ */
+public class MosaicRestrictionTransactionServiceTest {
+
+
+    private NetworkType networkType = NetworkType.MIJIN_TEST;
+    private MosaicRestrictionTransactionServiceImpl service;
+    private RestrictionMosaicRepository restrictionMosaicRepository;
+
+    private NamespaceRepository namespaceRepository;
+
+    private Account account1 = Account.generateNewAccount(networkType);
+    private Account account2 = Account.generateNewAccount(networkType);
+    private NamespaceId accountAlias1 = NamespaceId.createFromName("accountAlias1".toLowerCase());
+    private NamespaceId accountAlias2 = NamespaceId.createFromName("accountAlias2".toLowerCase());
+
+
+    private MosaicId mosaicId1 = MosaicId
+        .createFromNonce(MosaicNonce.createRandom(), account1.getPublicAccount());
+    private MosaicId mosaicId2 = MosaicId
+        .createFromNonce(MosaicNonce.createRandom(), account2.getPublicAccount());
+
+    private NamespaceId mosaicAlias1 = NamespaceId.createFromName("mosaicAlias1".toLowerCase());
+    private NamespaceId mosaicAlias2 = NamespaceId.createFromName("mosaicAlias2".toLowerCase());
+
+    private MosaicId mosaicIdWrongKey = new MosaicId("AAAAAAAAAAAAAAAA");
+    private MosaicId mosaicIdNotFound = new MosaicId("BBBBBBBBBBBBBBBB");
+
+    private BigInteger restrictionKey = BigInteger.TEN;
+
+    @BeforeEach
+    void setup() {
+
+        RepositoryFactory factory = mock(RepositoryFactory.class);
+        restrictionMosaicRepository = mock(RestrictionMosaicRepository.class);
+        when(factory.createRestrictionMosaicRepository()).thenReturn(
+            restrictionMosaicRepository);
+
+        namespaceRepository = mock(NamespaceRepository.class);
+        when(factory.createNamespaceRepository()).thenReturn(namespaceRepository);
+
+        when(factory.getNetworkType()).thenReturn(Observable.just(networkType));
+        service = new MosaicRestrictionTransactionServiceImpl(factory);
+
+        when(restrictionMosaicRepository
+            .getMosaicGlobalRestriction(eq(mosaicId1)))
+            .thenReturn(Observable.just(mockGlobalRestriction()));
+
+        when(restrictionMosaicRepository
+            .getMosaicGlobalRestriction(eq(mosaicId2)))
+            .thenReturn(Observable.just(mockGlobalRestriction()));
+
+        when(restrictionMosaicRepository
+            .getMosaicGlobalRestriction(eq(mosaicIdWrongKey)))
+            .thenReturn(Observable.error(() -> new IllegalStateException("Not a nice mosaic id")));
+
+        when(restrictionMosaicRepository
+            .getMosaicGlobalRestriction(eq(mosaicIdNotFound)))
+            .thenReturn(Observable
+                .error(() -> new RepositoryCallException("NotFound", 404,
+                    new IllegalStateException())));
+
+        when(restrictionMosaicRepository
+            .getMosaicAddressRestriction(eq(mosaicId1), eq(account1.getAddress())))
+            .thenReturn(Observable.just(mockAddressRestriction()));
+
+        when(restrictionMosaicRepository
+            .getMosaicAddressRestriction(eq(mosaicId2), eq(account1.getAddress())))
+            .thenReturn(Observable
+                .error(() -> new RepositoryCallException("NotFound", 404,
+                    new IllegalStateException())));
+
+        when(restrictionMosaicRepository
+            .getMosaicAddressRestriction(eq(mosaicIdWrongKey), eq(account1.getAddress())))
+            .thenReturn(Observable.error(() -> new IllegalStateException("Not a nice mosaic id")));
+
+        when(restrictionMosaicRepository
+            .getMosaicAddressRestriction(eq(mosaicIdNotFound), eq(account1.getAddress())))
+            .thenReturn(Observable
+                .error(() -> new RepositoryCallException("NotFound", 404,
+                    new IllegalStateException())));
+
+        when(namespaceRepository.getNamespace(Mockito.any()))
+            .thenReturn(Observable.error(new IllegalStateException("Alias does not exist")));
+
+        when(namespaceRepository.getNamespace(accountAlias1))
+            .thenReturn(Observable.just(createAlias(account1.getAddress())));
+
+        when(namespaceRepository.getNamespace(accountAlias2))
+            .thenReturn(Observable.just(createAlias(account2.getAddress())));
+
+        when(namespaceRepository.getNamespace(mosaicAlias1))
+            .thenReturn(Observable.just(createAlias(mosaicId1)));
+
+        when(namespaceRepository.getNamespace(mosaicAlias2))
+            .thenReturn(Observable.just(createAlias(mosaicId2)));
+
+    }
+
+    private NamespaceInfo createAlias(Address address) {
+
+        return new NamespaceInfo(true, 0, "metadaId", NamespaceRegistrationType.ROOT_NAMESPACE, 1,
+            Collections.emptyList(), null, null, BigInteger.ONE, BigInteger.TEN,
+            new AddressAlias(address));
+    }
+
+    private NamespaceInfo createAlias(MosaicId mosaicId) {
+
+        return new NamespaceInfo(true, 0, "metadaId", NamespaceRegistrationType.ROOT_NAMESPACE, 1,
+            Collections.emptyList(), null, null, BigInteger.ONE, BigInteger.TEN,
+            new MosaicAlias(mosaicId));
+    }
+
+
+    @Test
+    void createMosaicGlobalRestrictionTransactionFactoryWhenExist() throws Exception {
+        MosaicGlobalRestrictionTransaction transaction = service
+            .createMosaicGlobalRestrictionTransactionFactory(mosaicId1, restrictionKey,
+                BigInteger.valueOf(30), MosaicRestrictionType.GE).toFuture().get().build();
+
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+        Assertions.assertEquals(mosaicId1, transaction.getMosaicId());
+        Assertions.assertEquals(restrictionKey, transaction.getRestrictionKey());
+        Assertions.assertEquals(new MosaicId(BigInteger.ZERO), transaction.getReferenceMosaicId());
+        Assertions.assertEquals(BigInteger.valueOf(30), transaction.getNewRestrictionValue());
+        Assertions.assertEquals(MosaicRestrictionType.GE, transaction.getNewRestrictionType());
+        Assertions.assertEquals(BigInteger.valueOf(20), transaction.getPreviousRestrictionValue());
+        Assertions.assertEquals(MosaicRestrictionType.EQ, transaction.getPreviousRestrictionType());
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+    }
+
+    @Test
+    void createMosaicGlobalRestrictionTransactionFactoryWhenExistUsingAlias() throws Exception {
+        MosaicGlobalRestrictionTransaction transaction = service
+            .createMosaicGlobalRestrictionTransactionFactory(mosaicAlias1, restrictionKey,
+                BigInteger.valueOf(30), MosaicRestrictionType.GE).toFuture().get().build();
+
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+        Assertions.assertEquals(mosaicId1, transaction.getMosaicId());
+        Assertions.assertEquals(restrictionKey, transaction.getRestrictionKey());
+        Assertions.assertEquals(new MosaicId(BigInteger.ZERO), transaction.getReferenceMosaicId());
+        Assertions.assertEquals(BigInteger.valueOf(30), transaction.getNewRestrictionValue());
+        Assertions.assertEquals(MosaicRestrictionType.GE, transaction.getNewRestrictionType());
+        Assertions.assertEquals(BigInteger.valueOf(20), transaction.getPreviousRestrictionValue());
+        Assertions.assertEquals(MosaicRestrictionType.EQ, transaction.getPreviousRestrictionType());
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+    }
+
+    @Test
+    void createMosaicGlobalRestrictionTransactionFactoryWhenDoesNotExist() throws Exception {
+        MosaicGlobalRestrictionTransaction transaction = service
+            .createMosaicGlobalRestrictionTransactionFactory(mosaicIdNotFound,
+                restrictionKey,
+                BigInteger.valueOf(30), MosaicRestrictionType.GE).toFuture().get().build();
+
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+        Assertions.assertEquals(mosaicIdNotFound, transaction.getMosaicId());
+        Assertions.assertEquals(restrictionKey, transaction.getRestrictionKey());
+        Assertions.assertEquals(new MosaicId(BigInteger.ZERO), transaction.getReferenceMosaicId());
+        Assertions.assertEquals(BigInteger.valueOf(30), transaction.getNewRestrictionValue());
+        Assertions.assertEquals(MosaicRestrictionType.GE, transaction.getNewRestrictionType());
+        Assertions.assertEquals(BigInteger.ZERO, transaction.getPreviousRestrictionValue());
+        Assertions
+            .assertEquals(MosaicRestrictionType.NONE, transaction.getPreviousRestrictionType());
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+    }
+
+    @Test
+    void createMosaicGlobalRestrictionTransactionFactoryWhenError() throws Exception {
+
+        IllegalStateException exception = Assertions
+            .assertThrows(IllegalStateException.class, () -> ExceptionUtils.propagate(() ->
+                service
+                    .createMosaicGlobalRestrictionTransactionFactory(mosaicIdWrongKey,
+                        restrictionKey,
+                        BigInteger.valueOf(30), MosaicRestrictionType.GE).toFuture().get()));
+
+        Assertions.assertEquals("Not a nice mosaic id", exception.getMessage());
+
+    }
+
+    @Test
+    void createMosaicGlobalRestrictionTransactionFactoryWhenAliasDoesNotExist() throws Exception {
+
+        IllegalArgumentException exception = Assertions
+            .assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.propagate(() ->
+                service
+                    .createMosaicGlobalRestrictionTransactionFactory(
+                        NamespaceId.createFromName("invalid"),
+                        restrictionKey,
+                        BigInteger.valueOf(30), MosaicRestrictionType.GE).toFuture().get()));
+
+        Assertions.assertEquals("MosaicId could not be resolved from alias e6f4c6cb5111b127",
+            exception.getMessage());
+
+    }
+
+
+    @Test
+    void createMosaicAddressRestrictionTransactionFactoryWhenExist() throws Exception {
+        MosaicAddressRestrictionTransaction transaction = service
+            .createMosaicAddressRestrictionTransactionFactory(mosaicId1,
+                restrictionKey, account1.getAddress(),
+                BigInteger.valueOf(40)).toFuture().get().build();
+
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+        Assertions.assertEquals(mosaicId1, transaction.getMosaicId());
+        Assertions.assertEquals(restrictionKey, transaction.getRestrictionKey());
+        Assertions.assertEquals(account1.getAddress(), transaction.getTargetAddress());
+        Assertions.assertEquals(BigInteger.valueOf(40), transaction.getNewRestrictionValue());
+        Assertions.assertEquals(BigInteger.valueOf(30), transaction.getPreviousRestrictionValue());
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+    }
+
+    @Test
+    void createMosaicAddressRestrictionTransactionFactoryWhenExistUsingAlias() throws Exception {
+        MosaicAddressRestrictionTransaction transaction = service
+            .createMosaicAddressRestrictionTransactionFactory(mosaicAlias1,
+                restrictionKey, accountAlias1,
+                BigInteger.valueOf(40)).toFuture().get().build();
+
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+        Assertions.assertEquals(mosaicId1, transaction.getMosaicId());
+        Assertions.assertEquals(restrictionKey, transaction.getRestrictionKey());
+        Assertions.assertEquals(account1.getAddress(), transaction.getTargetAddress());
+        Assertions.assertEquals(BigInteger.valueOf(40), transaction.getNewRestrictionValue());
+        Assertions.assertEquals(BigInteger.valueOf(30), transaction.getPreviousRestrictionValue());
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+    }
+
+    @Test
+    void createMosaicAddressRestrictionTransactionFactoryWhenDoesNotExist() throws Exception {
+        MosaicAddressRestrictionTransaction transaction = service
+            .createMosaicAddressRestrictionTransactionFactory(mosaicId2,
+                restrictionKey, account1.getAddress(),
+                BigInteger.valueOf(40)).toFuture().get().build();
+
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+        Assertions.assertEquals(mosaicId2, transaction.getMosaicId());
+        Assertions.assertEquals(restrictionKey, transaction.getRestrictionKey());
+        Assertions.assertEquals(account1.getAddress(), transaction.getTargetAddress());
+        Assertions.assertEquals(BigInteger.valueOf(40), transaction.getNewRestrictionValue());
+        Assertions.assertEquals(new BigInteger("FFFFFFFFFFFFFFFF", 16),
+            transaction.getPreviousRestrictionValue());
+        Assertions.assertEquals(networkType, transaction.getNetworkType());
+    }
+
+    @Test
+    void createMosaicAddressRestrictionTransactionFactoryWhenGlobalNotFound() throws Exception {
+
+        IllegalArgumentException exception = Assertions
+            .assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.propagate(() ->
+                service
+                    .createMosaicAddressRestrictionTransactionFactory(mosaicIdNotFound,
+                        restrictionKey, account1.getAddress(),
+                        BigInteger.valueOf(30)).toFuture().get()));
+
+        Assertions.assertEquals("Global restriction is not valid for RestrictionKey: 10",
+            exception.getMessage());
+
+    }
+
+    @Test
+    void createMosaicAddressRestrictionTransactionFactoryWhenAliasesNotFound() throws Exception {
+
+        IllegalArgumentException exception = Assertions
+            .assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.propagate(() ->
+                service
+                    .createMosaicAddressRestrictionTransactionFactory(
+                        NamespaceId.createFromName("invalidmosaicalias"),
+                        restrictionKey, NamespaceId.createFromName("invalidaddressaslias"),
+                        BigInteger.valueOf(30)).toFuture().get()));
+
+        Assertions.assertEquals("MosaicId could not be resolved from alias 9ca319e451849811",
+            exception.getMessage());
+
+    }
+
+    @Test
+    void createMosaicAddressRestrictionTransactionFactoryWhenAddressAliasNotFound() {
+
+        IllegalArgumentException exception = Assertions
+            .assertThrows(IllegalArgumentException.class, () -> ExceptionUtils.propagate(() ->
+                service
+                    .createMosaicAddressRestrictionTransactionFactory(
+                        mosaicAlias1,
+                        restrictionKey, NamespaceId.createFromName("invalidaddressaslias"),
+                        BigInteger.valueOf(30)).toFuture().get()));
+
+        Assertions.assertEquals("Address could not be resolved from alias 98cc55cca3f13503",
+            exception.getMessage());
+
+    }
+
+    @Test
+    void createMosaicAddressRestrictionTransactionFactoryWhenError() throws Exception {
+
+        IllegalStateException exception = Assertions
+            .assertThrows(IllegalStateException.class, () -> ExceptionUtils.propagate(() ->
+                service
+                    .createMosaicAddressRestrictionTransactionFactory(mosaicIdWrongKey,
+                        restrictionKey, account1.getAddress(),
+                        BigInteger.valueOf(30)).toFuture().get()));
+
+        Assertions.assertEquals("Not a nice mosaic id", exception.getMessage());
+
+    }
+
+
+    private MosaicGlobalRestriction mockGlobalRestriction() {
+        return new MosaicGlobalRestriction(
+            "AAAA",
+            MosaicRestrictionEntryType.GLOBAL,
+            mosaicId1,
+            Collections.singletonMap(restrictionKey,
+                new MosaicGlobalRestrictionItem(mosaicId1, BigInteger.valueOf(20),
+                    MosaicRestrictionType.EQ)));
+    }
+
+    private MosaicAddressRestriction mockAddressRestriction() {
+        return new MosaicAddressRestriction(
+            "BBBB",
+            MosaicRestrictionEntryType.GLOBAL,
+            mosaicId1,
+            account1.getAddress(),
+            Collections.singletonMap(restrictionKey, BigInteger.valueOf(30)));
+    }
+
+}

--- a/sdk-core/src/test/java/io/nem/sdk/infrastructure/MosaicRestrictionTransactionServiceTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/infrastructure/MosaicRestrictionTransactionServiceTest.java
@@ -189,7 +189,7 @@ public class MosaicRestrictionTransactionServiceTest {
                 BigInteger.valueOf(30), MosaicRestrictionType.GE).toFuture().get().build();
 
         Assertions.assertEquals(networkType, transaction.getNetworkType());
-        Assertions.assertEquals(mosaicId1, transaction.getMosaicId());
+        Assertions.assertEquals(mosaicAlias1, transaction.getMosaicId());
         Assertions.assertEquals(restrictionKey, transaction.getRestrictionKey());
         Assertions.assertEquals(new MosaicId(BigInteger.ZERO), transaction.getReferenceMosaicId());
         Assertions.assertEquals(BigInteger.valueOf(30), transaction.getNewRestrictionValue());
@@ -273,9 +273,9 @@ public class MosaicRestrictionTransactionServiceTest {
                 BigInteger.valueOf(40)).toFuture().get().build();
 
         Assertions.assertEquals(networkType, transaction.getNetworkType());
-        Assertions.assertEquals(mosaicId1, transaction.getMosaicId());
+        Assertions.assertEquals(mosaicAlias1, transaction.getMosaicId());
         Assertions.assertEquals(restrictionKey, transaction.getRestrictionKey());
-        Assertions.assertEquals(account1.getAddress(), transaction.getTargetAddress());
+        Assertions.assertEquals(accountAlias1, transaction.getTargetAddress());
         Assertions.assertEquals(BigInteger.valueOf(40), transaction.getNewRestrictionValue());
         Assertions.assertEquals(BigInteger.valueOf(30), transaction.getPreviousRestrictionValue());
         Assertions.assertEquals(networkType, transaction.getNetworkType());


### PR DESCRIPTION
New mosaic restriction service supports aliases
Implemented AliasService
Improved MetadataTransactionService so unresolved mosaic ids are supported (alias support)

Chat about the implemenation

https://nem2.slack.com/archives/CEZKUE4KB/p1576101956352300