### PR TITLE
Basic fix of ResolutionStatement hash

### DIFF
--- a/sdk-core/src/main/java/io/nem/sdk/model/receipt/ResolutionEntry.java
+++ b/sdk-core/src/main/java/io/nem/sdk/model/receipt/ResolutionEntry.java
@@ -94,8 +94,8 @@ public class ResolutionEntry<T> {
     public byte[] serialize() {
         final byte[] resolvedBytes = getResolvedBytes();
         final ByteBuffer buffer = ByteBuffer.allocate(8 + resolvedBytes.length);
-        buffer.put(resolvedBytes);
         buffer.put(getReceiptSource().serialize());
+        buffer.put(resolvedBytes);
         return buffer.array();
     }
 

--- a/sdk-core/src/test/java/io/nem/sdk/model/receipt/ResolutionStatementTest.java
+++ b/sdk-core/src/test/java/io/nem/sdk/model/receipt/ResolutionStatementTest.java
@@ -135,7 +135,20 @@ public class ResolutionStatementTest {
     }
 
     @Test
-    void shouldGenerateHash() {
+    void shouldGenerateHashAddress() {
+        List<ResolutionEntry<Address>> resolutionEntries = new ArrayList<>();
+        resolutionEntries.add(addressResolutionEntry);
+        AddressResolutionStatement resolutionStatement = new AddressResolutionStatement(
+            BigInteger.TEN, address, resolutionEntries);
+
+        String hash = resolutionStatement.generateHash(networkType);
+
+        assertFalse(hash.isEmpty());
+        assertEquals("DD7E0D121A33C7133366F8FD36DD6CD5DE01D9008BA9369D2B7DA1BCCBB04A72", hash);
+    }
+
+    @Test
+    void shouldGenerateHashMosaic() {
         List<ResolutionEntry<MosaicId>> resolutionEntries = new ArrayList<>();
         resolutionEntries.add(mosaicResolutionEntry);
         MosaicResolutionStatement resolutionStatement = new MosaicResolutionStatement(
@@ -144,7 +157,7 @@ public class ResolutionStatementTest {
         String hash = resolutionStatement.generateHash(networkType);
 
         assertFalse(hash.isEmpty());
-        assertEquals("C965152CBD197283CC9F7AFD7F8C4C3FF03B0B54FCE7C8F4820F966AB0591A5C", hash);
+        assertEquals("9BB7E01FAEA831E790E4A2DE8DBEDB32F73889493F6B1BC02031457CB655F6D0", hash);
     }
 
 }

--- a/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/ReceiptMappingOkHttpTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/sdk/infrastructure/okhttp/ReceiptMappingOkHttpTest.java
@@ -35,7 +35,7 @@ public class ReceiptMappingOkHttpTest {
     public void getMosaicResolutionStatementHash() {
         Statement statement = getStatement();
         Assertions
-            .assertEquals("99381CE398D3AAE110FC97E984D7D35A710A5C525A4F959EC8916B382DE78A63",
+            .assertEquals("DE29FB6356530E5D1FBEE0A84202520C155D882C46EA74456752D6C75F0707B3",
                 statement.getMosaicResolutionStatement().get(0).generateHash(networkType));
     }
 
@@ -51,7 +51,7 @@ public class ReceiptMappingOkHttpTest {
     public void getAddressResolutionStatementsHash() {
         Statement statement = getStatement();
         Assertions
-            .assertEquals("6967470641BC527768CDC29998F4A3350813FDF2E40D1C97AB0BBA36B9AF649E",
+            .assertEquals("812AA120525990BE821035BC9CBCCD569F807B5338BA9D13DD63D99F3697ACCA",
                 statement.getAddressResolutionStatements().get(0).generateHash(networkType));
     }
 

--- a/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/ReceiptMappingVertxTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/sdk/infrastructure/vertx/ReceiptMappingVertxTest.java
@@ -33,7 +33,7 @@ public class ReceiptMappingVertxTest {
     public void getMosaicResolutionStatementHash() {
         Statement statement = getStatement();
         Assertions
-            .assertEquals("99381CE398D3AAE110FC97E984D7D35A710A5C525A4F959EC8916B382DE78A63",
+            .assertEquals("DE29FB6356530E5D1FBEE0A84202520C155D882C46EA74456752D6C75F0707B3",
                 statement.getMosaicResolutionStatement().get(0).generateHash(networkType));
     }
 
@@ -49,7 +49,7 @@ public class ReceiptMappingVertxTest {
     public void getAddressResolutionStatementsHash() {
         Statement statement = getStatement();
         Assertions
-            .assertEquals("6967470641BC527768CDC29998F4A3350813FDF2E40D1C97AB0BBA36B9AF649E",
+            .assertEquals("812AA120525990BE821035BC9CBCCD569F807B5338BA9D13DD63D99F3697ACCA",
                 statement.getAddressResolutionStatements().get(0).generateHash(networkType));
     }
 


### PR DESCRIPTION
This is a basic fix of https://github.com/nemtech/nem2-sdk-java/issues/222 but still not using the catbuffer generated code.

The catbuffer refactoring will be done in https://github.com/nemtech/nem2-sdk-java/issues/203